### PR TITLE
Add ability to poll seed node for peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ make
 ```
 
 ## Usage
-There is an example load testing configuration file in the `examples` folder.
-This example demonstrates usage with the following configuration:
+There are example load testing configuration files in the `examples` folder. The
+`load-test.toml` example demonstrates usage with the following configuration:
 
 * A single Tendermint node with RPC endpoint available at `localhost:26657`
 * The load testing master bound to `localhost:35000`

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,16 @@
+# Example Configuration Files
+
+Each TOML file in this folder provides an example as to how the load testing
+tool can be configured. The following configurations are available at present:
+
+* `load-test.toml` - Executes using the `kvstore-http` client type with 2 slave
+  nodes against a Tendermint node running on localhost. Interacts with the node
+  via the HTTP RPC interface.
+* `load-test-websockets.toml` - Executes the `kvstore-websockets` client type
+  with 2 slave nodes against a Tendermint node running on localhost. Interacts
+  with the node via the WebSockets RPC interface.
+* `load-test-autodetect-peers.toml` - Executes the `kvstore-http` client type
+  with 2 slave nodes against a Tendermint node running on localhost. Interacts
+  with the node via the HTTP RPC interface. Attempts to glean a list of
+  Tendermint node targets from the Tendermint node running on localhost through
+  its `net_info` RPC endpoint.

--- a/examples/load-test-autodetect-peers.toml
+++ b/examples/load-test-autodetect-peers.toml
@@ -54,7 +54,7 @@ wait_after_finished = "10s"
 
     # If test_network.autodetect.enabled is set to true, this is how many
     # targets to expect prior to starting the load testing.
-    expect_targets = 3
+    expect_targets = 1
 
     # The maximum time to wait while polling the seed_node for the required
     # number of targets before considering the entire load test a failure.

--- a/examples/load-test-autodetect-peers.toml
+++ b/examples/load-test-autodetect-peers.toml
@@ -50,7 +50,7 @@ wait_after_finished = "10s"
 
     # If test_network.autodetect.enabled is set to true, this seed_node address
     # will be used to try to obtain a list of targets for load testing.
-    seed_node = "tcp://localhost:26657"
+    seed_node = "tcp://tik0.staging.interchain.io:26657"
 
     # If test_network.autodetect.enabled is set to true, this is how many
     # targets to expect prior to starting the load testing.
@@ -59,6 +59,9 @@ wait_after_finished = "10s"
     # The maximum time to wait while polling the seed_node for the required
     # number of targets before considering the entire load test a failure.
     expect_targets_within = "3m"
+
+    # Whether or not to consider the seed node as part of the test network.
+    target_seed_node = true
 
     # This array is only taken into account if test_network.autodetect.enabled
     # is set to false.

--- a/examples/load-test-autodetect-peers.toml
+++ b/examples/load-test-autodetect-peers.toml
@@ -46,11 +46,11 @@ wait_after_finished = "10s"
     # Set to true if you want the test network's nodes to be automatically
     # detected from a single Tendermint node. The master will poll the
     # seed_node for other peers to use as targets.
-    enabled = false
+    enabled = true
 
     # If test_network.autodetect.enabled is set to true, this seed_node address
     # will be used to try to obtain a list of targets for load testing.
-    seed_node = "http://192.168.2.1:26657"
+    seed_node = "tcp://localhost:26657"
 
     # If test_network.autodetect.enabled is set to true, this is how many
     # targets to expect prior to starting the load testing.

--- a/examples/load-test-websockets.toml
+++ b/examples/load-test-websockets.toml
@@ -45,7 +45,7 @@ wait_after_finished = "10s"
     [test_network.autodetect]
     # Set to true if you want the test network's nodes to be automatically
     # detected from a single Tendermint node. The master will poll the
-    # autodetect_seed_node for other peers to use as targets.
+    # seed_node for other peers to use as targets.
     enabled = false
 
     # If test_network.autodetect.enabled is set to true, this seed_node address

--- a/examples/load-test-websockets.toml
+++ b/examples/load-test-websockets.toml
@@ -60,6 +60,9 @@ wait_after_finished = "10s"
     # number of targets before considering the entire load test a failure.
     expect_targets_within = "3m"
 
+    # Whether or not to consider the seed node as part of the test network.
+    target_seed_node = false
+
     # This array is only taken into account if test_network.autodetect.enabled
     # is set to false.
     [[test_network.targets]]

--- a/examples/load-test.toml
+++ b/examples/load-test.toml
@@ -60,6 +60,9 @@ wait_after_finished = "10s"
     # number of targets before considering the entire load test a failure.
     expect_targets_within = "3m"
 
+    # Whether or not to consider the seed node as part of the test network.
+    target_seed_node = false
+
     # This array is only taken into account if test_network.autodetect.enabled
     # is set to false.
     [[test_network.targets]]

--- a/pkg/loadtest/clients/clients.go
+++ b/pkg/loadtest/clients/clients.go
@@ -8,11 +8,16 @@ import (
 // ClientType produces client factories.
 type ClientType interface {
 	// NewFactory must take the given parameters and construct a Factory.
-	NewFactory(cfg Config, targets []string, id string) (Factory, error)
+	NewFactory(cfg Config, id string) (Factory, error)
 }
 
 // Factory produces clients.
 type Factory interface {
+	// SetTargets must allow the caller to configure the targets for load
+	// testing prior to execution.
+	SetTargets(targets []string) error
+
+	// NewClient instantiates a client.
 	NewClient() Client
 }
 

--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -65,6 +65,7 @@ type TestNetworkAutodetectConfig struct {
 	SeedNode            string                      `toml:"seed_node"`      // The seed node from which to find other peers/targets.
 	ExpectTargets       int                         `toml:"expect_targets"` // The number of targets to expect prior to starting load testing.
 	ExpectTargetsWithin timeutils.ParseableDuration `toml:"expect_targets_within"`
+	TargetSeedNode      bool                        `toml:"target_seed_node"` // Whether or not to include the seed node itself in load testing.
 }
 
 // TestNetworkTargetConfig encapsulates the configuration for each node in the

--- a/pkg/loadtest/master.go
+++ b/pkg/loadtest/master.go
@@ -188,6 +188,12 @@ func (m *Master) querySeedForTargets(c *client.HTTP) error {
 			URL: fmt.Sprintf("%s://%s:%s", peerURL.Scheme, peer.RemoteIP, peerURL.Port()),
 		}
 	}
+	if m.cfg.TestNetwork.Autodetect.TargetSeedNode {
+		m.targets[m.cfg.TestNetwork.Autodetect.SeedNode] = TestNetworkTargetConfig{
+			ID:  "seed_node",
+			URL: m.cfg.TestNetwork.Autodetect.SeedNode,
+		}
+	}
 	m.logger.Debug("Got response from seed node", "targetCount", len(m.targets))
 	return nil
 }

--- a/pkg/loadtest/models.go
+++ b/pkg/loadtest/models.go
@@ -15,10 +15,18 @@ type remoteSlave struct {
 	Interactions int64      `json:"interactions"`
 }
 
-// resMessage is a generic way of representing a message string (either error or
-// otherwise).
+// resMessage is a generic way of representing a result message string (either
+// error or otherwise).
 type resMessage struct {
 	Message string `json:"message"`
+}
+
+// testNetworkTargets is a data structure returned by the master when a slave
+// attempts to register with the master when the list of targets is to be
+// obtained from a Tendermint peer node as opposed to a predefined list of
+// targets.
+type testNetworkTargets struct {
+	Targets []TestNetworkTargetConfig
 }
 
 func toJSON(msg interface{}) (string, error) {


### PR DESCRIPTION
This adds the necessary functionality for the master to poll a Tendermint seed node for new peers until a minimum number of peers is found before allowing slaves to connect. Once all necessary peers are found, slaves will be accepted and will be given a list of target nodes to use during testing.