### PR TITLE
Add feature to allow for unlimited transactions, but limited time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## v0.2.1
+* Allow clients to continuously send transactions until the maximum time limit
+  is reached without having a limit imposed on the number of transactions.
+
+## v0.2.0
+* First alpha release.
+* Refactored comms mechanism between master and slaves to use HTTP for more
+  robust communication and to simplify.
+* Added the WebSockets-based client for interacting with Tendermint nodes over
+  WebSockets (`kvstore-websockets`).
+
+## v0.1.0
+* Initial release to configure release management.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## v0.2.1
-* Allow clients to continuously send transactions until the maximum time limit
-  is reached without having a limit imposed on the number of transactions.
+* [\#10](https://github.com/interchainio/tm-load-test/pull/10) Allow clients
+  to continuously send transactions until the maximum time limit is reached
+  without having a limit imposed on the number of transactions.
 
 ## v0.2.0
 * First alpha release.

--- a/pkg/loadtest/integration_test.go
+++ b/pkg/loadtest/integration_test.go
@@ -198,6 +198,9 @@ func waitAndAssertCorrect(t *testing.T, tc *testCase) {
 					t.Errorf("expected %d interactions from slave %d, but got %d", tc.expectedSlaveInteractions[i], i, r.summary.Interactions)
 				}
 			}
+
+		case <-time.After(maxTestTime):
+			t.Error("maximum test time expired")
 		}
 	}
 	if tc.maxInteractions == -1 {

--- a/pkg/loadtest/integration_test.go
+++ b/pkg/loadtest/integration_test.go
@@ -67,7 +67,7 @@ type = "kvstore-websockets"
 additional_params = ""
 spawn = 10
 spawn_rate = 10.0
-max_interactions = 1
+max_interactions = {{.MaxInteractions}}
 interaction_timeout = "11s"
 max_test_time = "10m"
 request_wait_min = "0ms"
@@ -83,11 +83,26 @@ type runResult struct {
 }
 
 type testConfig struct {
-	MasterAddr string
-	RPCAddr    string
+	MasterAddr      string
+	RPCAddr         string
+	MaxInteractions int
 }
 
-func generateConfig(tpl string) (string, error) {
+type testCase struct {
+	rawConfig       string
+	maxInteractions int
+	maxTestTime     time.Duration
+
+	startTime  time.Time
+	masterChan chan runResult
+	slaveChans []chan runResult
+
+	expectedMasterInteractions int64
+	expectedSlaveInteractions  []int64
+	expectedMinTestTime        time.Duration
+}
+
+func generateConfig(tpl string, maxInteractions int) (string, error) {
 	masterAddr, err := loadtest.ResolveBindAddr("127.0.0.1:")
 	if err != nil {
 		return "", err
@@ -95,8 +110,9 @@ func generateConfig(tpl string) (string, error) {
 
 	// get the Tendermint RPC address
 	testCfg := testConfig{
-		MasterAddr: masterAddr,
-		RPCAddr:    rpctest.GetConfig().RPC.ListenAddress,
+		MasterAddr:      masterAddr,
+		RPCAddr:         rpctest.GetConfig().RPC.ListenAddress,
+		MaxInteractions: maxInteractions,
 	}
 
 	var b strings.Builder
@@ -117,15 +133,25 @@ func init() {
 }
 
 func TestKVStoreHTTPIntegrationWithTendermintNode(t *testing.T) {
-	runIntegrationTest(t, kvstoreHTTPConfig)
+	runIntegrationTest(t, &testCase{
+		rawConfig:                  kvstoreHTTPConfig,
+		maxInteractions:            1,
+		expectedMasterInteractions: 2 * 10 * 1, // no. of slaves * no. of clients * max interactions
+		expectedSlaveInteractions:  []int64{10, 10},
+	})
 }
 
 func TestKVStoreWebSocketsIntegrationWithTendermintNode(t *testing.T) {
-	runIntegrationTest(t, kvstoreWebSocketsConfig)
+	runIntegrationTest(t, &testCase{
+		rawConfig:                  kvstoreWebSocketsConfig,
+		maxInteractions:            1,
+		expectedMasterInteractions: 2 * 10 * 1, // no. of slaves * no. of clients * max interactions
+		expectedSlaveInteractions:  []int64{10, 10},
+	})
 }
 
-func runIntegrationTest(t *testing.T, rawConfig string) {
-	testCfg, err := generateConfig(rawConfig)
+func runIntegrationTest(t *testing.T, tc *testCase) {
+	testCfg, err := generateConfig(tc.rawConfig, tc.maxInteractions)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,42 +162,48 @@ func runIntegrationTest(t *testing.T, rawConfig string) {
 		t.Fatal("Failed to parse integration test config.", err)
 	}
 
-	masterChan := spawnRunner(cfg, loadtest.RunMasterWithConfig)
-	slave1Chan := spawnRunner(cfg, loadtest.RunSlaveWithConfig)
-	slave2Chan := spawnRunner(cfg, loadtest.RunSlaveWithConfig)
+	tc.startTime = time.Now()
+	tc.masterChan = spawnRunner(cfg, loadtest.RunMasterWithConfig)
+	tc.slaveChans = make([]chan runResult, 2)
+	tc.slaveChans[0] = spawnRunner(cfg, loadtest.RunSlaveWithConfig)
+	tc.slaveChans[1] = spawnRunner(cfg, loadtest.RunSlaveWithConfig)
+	waitAndAssertCorrect(t, tc)
+}
 
-	// wait for load testing to successfully complete
-	for finished := 0; finished < 3; {
+func waitAndAssertCorrect(t *testing.T, tc *testCase) {
+	// get the master's results
+	select {
+	case r := <-tc.masterChan:
+		if r.err != nil {
+			t.Error(r.err)
+		}
+		if tc.maxInteractions > -1 {
+			if r.summary.Interactions != tc.expectedMasterInteractions {
+				t.Errorf("expected %d interactions from master, but got %d", tc.expectedMasterInteractions, r.summary.Interactions)
+			}
+		}
+
+	case <-time.After(maxTestTime):
+		t.Error("maximum test time expired")
+	}
+	// get all slaves' results
+	for i, slavec := range tc.slaveChans {
 		select {
-		case r := <-masterChan:
-			finished++
+		case r := <-slavec:
 			if r.err != nil {
 				t.Error(r.err)
 			}
-			if r.summary.Interactions != 20 {
-				t.Errorf("expected 20 interactions from master, but got %d", r.summary.Interactions)
+			if tc.maxInteractions > -1 {
+				if r.summary.Interactions != tc.expectedSlaveInteractions[i] {
+					t.Errorf("expected %d interactions from slave %d, but got %d", tc.expectedSlaveInteractions[i], i, r.summary.Interactions)
+				}
 			}
-
-		case r := <-slave1Chan:
-			finished++
-			if r.err != nil {
-				t.Error(r.err)
-			}
-			if r.summary.Interactions != 10 {
-				t.Errorf("expected 10 interactions from slave 1, but got %d", r.summary.Interactions)
-			}
-
-		case r := <-slave2Chan:
-			finished++
-			if r.err != nil {
-				t.Error(r.err)
-			}
-			if r.summary.Interactions != 10 {
-				t.Errorf("expected 10 interactions from slave 2, but got %d", r.summary.Interactions)
-			}
-
-		case <-time.After(maxTestTime):
-			t.Fatal("Maximum test time expired")
+		}
+	}
+	if tc.maxInteractions == -1 {
+		testTime := time.Since(tc.startTime)
+		if testTime < tc.maxTestTime {
+			t.Errorf("expected test to take a minimum of %s, but took %s", tc.startTime.String(), testTime.String())
 		}
 	}
 }


### PR DESCRIPTION
We need to be able to run load tests for a specific period of time without a limit on the number of transactions during that time period. This PR enables this functionality.