### PR TITLE
Add basic HTTP authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## v0.2.1
+* [\#11](https://github.com/interchainio/tm-load-test/pull/11) Allow for basic
+  HTTP authentication between the master and slave nodes for additional
+  security.
 * [\#10](https://github.com/interchainio/tm-load-test/pull/10) Allow clients
   to continuously send transactions until the maximum time limit is reached
   without having a limit imposed on the number of transactions.

--- a/examples/load-test-autodetect-peers.toml
+++ b/examples/load-test-autodetect-peers.toml
@@ -2,6 +2,14 @@
 # The host IP/port to which to bind the master
 bind = "127.0.0.1:35000"
 
+    [master.auth]
+    # Is basic HTTP authentication enabled when attempting to access the master?
+    enabled = false
+    # Username to use in basic HTTP authentication.
+    username = "loadtestuser"
+    # The bcrypt hash of the password required to validate slaves.
+    password_hash = "$2a$12$.pR8I4VZttp2PoemVDvxbuDRpj25svTxa6NL2oVMazGGjq5S4vOum"
+
 # How many slaves to expect to connect before starting the load test
 expect_slaves = 2
 
@@ -20,9 +28,8 @@ wait_after_finished = "10s"
 # pick a random port.
 bind = "127.0.0.1:"
 
-# IP address and port through which to reach the master (could be different
-# from the bind address above, e.g. if the master is bound to 0.0.0.0:35000,
-# we still need an external address through which to access the master).
+# HTTP address by which the master can be reached. If the master requires
+# authentication, include the username:password in the URL below.
 master = "http://127.0.0.1:35000"
 
 # How long to keep polling for the master before considering the master to have

--- a/examples/load-test-websockets.toml
+++ b/examples/load-test-websockets.toml
@@ -2,6 +2,14 @@
 # The host IP/port to which to bind the master
 bind = "127.0.0.1:35000"
 
+    [master.auth]
+    # Is basic HTTP authentication enabled when attempting to access the master?
+    enabled = false
+    # Username to use in basic HTTP authentication.
+    username = "loadtestuser"
+    # The bcrypt hash of the password required to validate slaves.
+    password_hash = "$2a$12$.pR8I4VZttp2PoemVDvxbuDRpj25svTxa6NL2oVMazGGjq5S4vOum"
+
 # How many slaves to expect to connect before starting the load test
 expect_slaves = 2
 
@@ -20,9 +28,8 @@ wait_after_finished = "10s"
 # pick a random port.
 bind = "127.0.0.1:"
 
-# IP address and port through which to reach the master (could be different
-# from the bind address above, e.g. if the master is bound to 0.0.0.0:35000,
-# we still need an external address through which to access the master).
+# HTTP address by which the master can be reached. If the master requires
+# authentication, include the username:password in the URL below.
 master = "http://127.0.0.1:35000"
 
 # How long to keep polling for the master before considering the master to have

--- a/examples/load-test.toml
+++ b/examples/load-test.toml
@@ -2,6 +2,14 @@
 # The host IP/port to which to bind the master
 bind = "127.0.0.1:35000"
 
+    [master.auth]
+    # Is basic HTTP authentication enabled when attempting to access the master?
+    enabled = false
+    # Username to use in basic HTTP authentication.
+    username = "loadtestuser"
+    # The bcrypt hash of the password required to validate slaves.
+    password_hash = "$2a$12$.pR8I4VZttp2PoemVDvxbuDRpj25svTxa6NL2oVMazGGjq5S4vOum"
+
 # How many slaves to expect to connect before starting the load test
 expect_slaves = 2
 
@@ -20,9 +28,8 @@ wait_after_finished = "10s"
 # pick a random port.
 bind = "127.0.0.1:"
 
-# IP address and port through which to reach the master (could be different
-# from the bind address above, e.g. if the master is bound to 0.0.0.0:35000,
-# we still need an external address through which to access the master).
+# HTTP address by which the master can be reached. If the master requires
+# authentication, include the username:password in the URL below.
 master = "http://127.0.0.1:35000"
 
 # How long to keep polling for the master before considering the master to have

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tendermint/go-amino v0.14.1 // indirect
 	github.com/tendermint/tendermint v0.31.3
-	golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a // indirect
+	golang.org/x/crypto v0.0.0-20190411191339-88737f569e3a
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 // indirect
 	golang.org/x/sys v0.0.0-20190411185658-b44545bcd369 // indirect
 	golang.org/x/tools v0.0.0-20190411180116-681f9ce8ac52 // indirect

--- a/pkg/loadtest/http.go
+++ b/pkg/loadtest/http.go
@@ -109,11 +109,11 @@ func longPoll(req *http.Request, singlePollTimeout, overallTimeout time.Duration
 	lastPoll := startTime
 	attempt := 0
 	for {
-		logger.Debug("Sending request", "attempt", attempt)
+		logger.Debug("Sending request", "attempt", attempt, "method", req.Method)
 		res, err := client.Do(req)
 		if err == nil {
 			defer res.Body.Close()
-			logger.Debug("Got response", "code", res.StatusCode)
+			logger.Debug("Got response", "code", res.StatusCode, "attempt", attempt)
 			if res.StatusCode == 200 {
 				body, err := ioutil.ReadAll(res.Body)
 				if err != nil {
@@ -121,11 +121,11 @@ func longPoll(req *http.Request, singlePollTimeout, overallTimeout time.Duration
 				}
 				// all's good
 				return body, nil
-			} else if res.StatusCode >= 400 {
-				return nil, fmt.Errorf("request failed with status code %d", res.StatusCode)
-			} else {
-				logger.Debug("Server not ready yet")
 			}
+			if res.StatusCode >= 400 {
+				return nil, fmt.Errorf("request failed with status code %d", res.StatusCode)
+			}
+			logger.Debug("Server not ready yet")
 		} else {
 			logger.Debug("Failed to send request, will try again", "err", err)
 			if time.Since(startTime) >= overallTimeout {

--- a/pkg/loadtest/slave.go
+++ b/pkg/loadtest/slave.go
@@ -89,9 +89,9 @@ func NewSlave(cfg *Config) (*Slave, error) {
 	maxInteractions := int64(cfg.Clients.Spawn) * int64(cfg.Clients.MaxInteractions)
 	if cfg.Clients.MaxInteractions == -1 {
 		maxInteractions = -1
-		logger.Debug("Slave stop criteria", "maxTime", cfg.Clients.MaxTestTime.Duration().String())
+		logger.Debug("Slave stop criterion", "maxTime", cfg.Clients.MaxTestTime.Duration().String())
 	} else {
-		logger.Debug("Slave stop criteria", "maxInteractions", maxInteractions)
+		logger.Debug("Slave stop criterion", "maxInteractions", maxInteractions)
 	}
 	return &Slave{
 		cfg:               cfg,


### PR DESCRIPTION
This PR adds basic HTTP authentication to the master/slave interaction. It uses bcrypt-based hashes to validate the password supplied by the slave. Operating this over TLS should provide additional security in the master/slave interaction.