### PR TITLE
Add basic HTTP authentication to tm-outage-sim-server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v0.3.0
+* [\#13](https://github.com/interchainio/tm-load-test/pull/13) - Add basic HTTP
+  authentication to `tm-outage-sim-server` utility.
 * [\#12](https://github.com/interchainio/tm-load-test/pull/12) - Add standalone
   mode to be able to run load testing tool locally in a simple way.
 * [\#11](https://github.com/interchainio/tm-load-test/pull/11) - Allow for basic

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 GOPATH ?= $(shell go env GOPATH)
-OUTPUT ?= build/tm-load-test
-.PHONY: build test lint
+BUILD_DIR ?= ./build
+.PHONY: build test lint clean
+.DEFAULT_GOAL := build
 
 build:
-	GO111MODULE=on go build -o $(OUTPUT) cmd/tm-load-test/main.go
+	GO111MODULE=on go build -o $(BUILD_DIR)/tm-load-test ./cmd/tm-load-test/main.go
+	GO111MODULE=on go build -o $(BUILD_DIR)/tm-outage-sim-server ./cmd/tm-outage-sim-server/main.go
 
 test:
 	GO111MODULE=on go test -cover -race ./...
@@ -13,20 +15,6 @@ $(GOPATH)/bin/golangci-lint:
 
 lint: $(GOPATH)/bin/golangci-lint
 	GO111MODULE=on $(GOPATH)/bin/golangci-lint run ./...
-
-### Dev area
-
-.DEFAULT_GOAL := build
-.PHONY: protos clean
-
-
-$(GOPATH)/bin/protoc-gen-gogoslick:
-	GO111MODULE=off go get -u github.com/gogo/protobuf/...
-
-protos: $(GOPATH)/bin/protoc-gen-gogoslick
-	$(GOPATH)/bin/protoc-gen-gogoslick --gogoslick_out=pkg/loadtest/messages/ \
-		-Ipkg/loadtest/messages/ \
-		loadtest.proto
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/cmd/tm-outage-sim-server/README.md
+++ b/cmd/tm-outage-sim-server/README.md
@@ -10,10 +10,15 @@ the Tendermint service up or down, respectively.
 
 ## Security
 **Do not run this service continuously alongside a production Tendermint
-instance**. This service is exclusively designed to help with configuring
-short-term, repeatable experiments. Running this service in a production
-environment where it is accessible from the public Internet could allow someone
-to bring down your Tendermint instance.
+instance**. Despite the fact that the current version of `tm-outage-sim-server`
+includes a basic HTTP authentication requirement, this might still allow an
+attacker to stop your Tendermint node.
+
+This application requires the relevant system privileges to be able to interact
+with the Tendermint service. See [this
+discussion](https://unix.stackexchange.com/q/215412) for an example as to how to
+configure a non-root user to have the relevant sudo privileges to start/stop a
+service.
 
 ## Requirements
 The following are minimum requirements for running this application:
@@ -25,7 +30,7 @@ The following are minimum requirements for running this application:
 
 To build `tm-outage-sim-server`, you will need:
 
-* Golang v1.11.5+
+* Golang v1.12+
 
 ## Running
 To run the application alongside Tendermint as a `systemd` service, use the
@@ -40,10 +45,10 @@ After=network-online.target
 
 [Service]
 Restart=on-failure
-User=root
-Group=root
+User=tm-outage-sim
+Group=tm-outage-sim
 PermissionsStartOnly=true
-ExecStart=/usr/bin/tm-outage-sim-server
+ExecStart=/usr/bin/tm-outage-sim-server -p "\$2a\$12$ac6f8zq9vvugNb3QXeOV9.RGFHeu8a7qhf9WIRAfH69a0k2j7J7wy"
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=tm-outage-sim-server
@@ -62,7 +67,7 @@ systemctl daemon-reload
 service tm-outage-sim-server start
 ```
 
-By default, the server binds to `0.0.0.0:34000`.
+By default, the server binds to `0.0.0.0:26680`.
 
 ## Usage
 To bring the Tendermint service up or down, simply do an HTTP POST to the
@@ -70,8 +75,8 @@ server:
 
 ```bash
 # Bring Tendermint up
-curl -s -X POST -d 'up' http://127.0.0.1:34000
+curl -s -X POST -d "up" http://tm-load-test:testpassword@127.0.0.1:26680
 
 # Bring Tendermint down
-curl -s -X POST -d 'down' http://127.0.0.1:34000
+curl -s -X POST -d "down" http://tm-load-test:testpassword@127.0.0.1:26680
 ```

--- a/internal/outagesim/http_interface_test.go
+++ b/internal/outagesim/http_interface_test.go
@@ -4,20 +4,32 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 )
 
+const testUser = "testuser"
+const testPassword = "testpassword"
+const testPasswordHash = "$2a$08$icFrbtWXmEHXZJ9cZWqQJ.j3DA8r1fHwKs.gXEDpDjN3TzGRFFO.y"
+
 func TestBringTendermintUp(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		MakeOutageEndpointHandler(
+			testUser,
+			testPasswordHash,
 			func() bool { return false },
 			func(string) error { return nil },
 		),
 	))
 	defer ts.Close()
 
-	r, err := http.Post(ts.URL, "text/plain", strings.NewReader("up"))
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsURL.User = url.UserPassword(testUser, testPassword)
+	r, err := http.Post(tsURL.String(), "text/plain", strings.NewReader("up"))
 	if err != nil {
 		t.Fatalf("Got unexpected error: %s", err)
 	}
@@ -29,13 +41,20 @@ func TestBringTendermintUp(t *testing.T) {
 func TestBringTendermintUpFailed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		MakeOutageEndpointHandler(
+			testUser,
+			testPasswordHash,
 			func() bool { return false },
 			func(string) error { return fmt.Errorf("Some error occurred") },
 		),
 	))
 	defer ts.Close()
 
-	r, err := http.Post(ts.URL, "text/plain", strings.NewReader("up"))
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsURL.User = url.UserPassword(testUser, testPassword)
+	r, err := http.Post(tsURL.String(), "text/plain", strings.NewReader("up"))
 	if err != nil {
 		t.Fatalf("Got unexpected error: %s", err)
 	}
@@ -47,13 +66,20 @@ func TestBringTendermintUpFailed(t *testing.T) {
 func TestBringTendermintDown(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		MakeOutageEndpointHandler(
+			testUser,
+			testPasswordHash,
 			func() bool { return true },
 			func(string) error { return nil },
 		),
 	))
 	defer ts.Close()
 
-	r, err := http.Post(ts.URL, "text/plain", strings.NewReader("down"))
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsURL.User = url.UserPassword(testUser, testPassword)
+	r, err := http.Post(tsURL.String(), "text/plain", strings.NewReader("down"))
 	if err != nil {
 		t.Fatalf("Got unexpected error: %s", err)
 	}
@@ -65,13 +91,20 @@ func TestBringTendermintDown(t *testing.T) {
 func TestBringTendermintDownFailed(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		MakeOutageEndpointHandler(
+			testUser,
+			testPasswordHash,
 			func() bool { return true },
 			func(string) error { return fmt.Errorf("Some error occurred") },
 		),
 	))
 	defer ts.Close()
 
-	r, err := http.Post(ts.URL, "text/plain", strings.NewReader("down"))
+	tsURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tsURL.User = url.UserPassword(testUser, testPassword)
+	r, err := http.Post(tsURL.String(), "text/plain", strings.NewReader("down"))
 	if err != nil {
 		t.Fatalf("Got unexpected error: %s", err)
 	}
@@ -83,6 +116,8 @@ func TestBringTendermintDownFailed(t *testing.T) {
 func TestInvalidHTTPMethod(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(
 		MakeOutageEndpointHandler(
+			testUser,
+			testPasswordHash,
 			func() bool { return true },
 			func(string) error { return nil },
 		),


### PR DESCRIPTION
This enhances the security of the `tm-outage-sim-server` utility, which allows us to bring a Tendermint node up/down through simple (now authenticated) POST requests.