### PR TITLE
Add outage simulator support to load testing tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v0.3.0
+* [\#14](https://github.com/interchainio/tm-load-test/pull/14) - Add support for
+  the outage simulator from the master node during load testing.
 * [\#13](https://github.com/interchainio/tm-load-test/pull/13) - Add basic HTTP
   authentication to `tm-outage-sim-server` utility.
 * [\#12](https://github.com/interchainio/tm-load-test/pull/12) - Add standalone

--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ the `master.expect_slaves` and `slave.master` parameters in your configuration
 file):
 
 ```bash
+# Initialize your local Tendermint node to ~/.tendermint
+tendermint init
+# Run a node with the kvstore proxy app
+tendermint node --proxy_app kvstore
+
 # Run the load test in standalone mode with the given configuration (-v sets
 # output logging to DEBUG level)
 ./build/tm-load-test -c examples/load-test.toml -mode standalone -v
@@ -43,7 +48,7 @@ The [`load-test.toml`](./examples/load-test.toml) example demonstrates usage
 with the following configuration:
 
 * A single Tendermint node with RPC endpoint available at `localhost:26657`
-* The load testing master bound to `localhost:35000`
+* The load testing master bound to `localhost:26670`
 * 2 slaves bound to arbitrary ports on `localhost`
 * Each slave spawns 50 clients
 * Each client executes 100 interactions with the Tendermint node

--- a/examples/load-test-autodetect-peers.toml
+++ b/examples/load-test-autodetect-peers.toml
@@ -1,6 +1,6 @@
 [master]
 # The host IP/port to which to bind the master
-bind = "127.0.0.1:35000"
+bind = "127.0.0.1:26670"
 
 # How many slaves to expect to connect before starting the load test
 expect_slaves = 2
@@ -34,7 +34,7 @@ bind = "127.0.0.1:"
 # authentication, include the username:password in the URL below. Alternatively,
 # include the username and password in the TMLOADTEST_MASTER_USERNAME and
 # TMLOADTEST_MASTER_PASSWORD environment variables when running the slave.
-master = "http://127.0.0.1:35000"
+master = "http://127.0.0.1:26670"
 
 # How long to keep polling for the master before considering the master to have
 # failed to start up at all.

--- a/examples/load-test-websockets.toml
+++ b/examples/load-test-websockets.toml
@@ -1,6 +1,6 @@
 [master]
 # The host IP/port to which to bind the master
-bind = "127.0.0.1:35000"
+bind = "127.0.0.1:26670"
 
 # How many slaves to expect to connect before starting the load test
 expect_slaves = 2
@@ -34,7 +34,7 @@ bind = "127.0.0.1:"
 # authentication, include the username:password in the URL below. Alternatively,
 # include the username and password in the TMLOADTEST_MASTER_USERNAME and
 # TMLOADTEST_MASTER_PASSWORD environment variables when running the slave.
-master = "http://127.0.0.1:35000"
+master = "http://127.0.0.1:26670"
 
 # How long to keep polling for the master before considering the master to have
 # failed to start up at all.

--- a/examples/load-test.toml
+++ b/examples/load-test.toml
@@ -1,6 +1,6 @@
 [master]
 # The host IP/port to which to bind the master
-bind = "127.0.0.1:35000"
+bind = "127.0.0.1:26670"
 
 # How many slaves to expect to connect before starting the load test
 expect_slaves = 2
@@ -34,7 +34,7 @@ bind = "127.0.0.1:"
 # authentication, include the username:password in the URL below. Alternatively,
 # include the username and password in the TMLOADTEST_MASTER_USERNAME and
 # TMLOADTEST_MASTER_PASSWORD environment variables when running the slave.
-master = "http://127.0.0.1:35000"
+master = "http://127.0.0.1:26670"
 
 # How long to keep polling for the master before considering the master to have
 # failed to start up at all.

--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -199,6 +199,20 @@ func (c *TestNetworkConfig) Validate() error {
 	return c.OutageSim.Validate()
 }
 
+// TargetsAsMap converts the internal targets array into a mapping of the target
+// nodes' IDs to their configurations.
+func (c *TestNetworkConfig) TargetsAsMap() (m map[string]TestNetworkTargetConfig) {
+	m = make(map[string]TestNetworkTargetConfig)
+	// we don't want to return any targets at all if we're autodetecting nodes
+	if c.Autodetect.Enabled {
+		return
+	}
+	for _, t := range c.Targets {
+		m[t.ID] = t
+	}
+	return
+}
+
 //
 // TestNetworkAutodetectConfig
 //

--- a/pkg/loadtest/integration_test.go
+++ b/pkg/loadtest/integration_test.go
@@ -135,7 +135,6 @@ type testCase struct {
 
 	expectedMasterInteractions int64
 	expectedSlaveInteractions  []int64
-	expectedMinTestTime        time.Duration
 }
 
 func generateConfig(tpl string, maxInteractions int, maxTestTime string) (string, error) {
@@ -186,15 +185,6 @@ func TestKVStoreWebSocketsIntegration(t *testing.T) {
 		maxTestTime:                time.Duration(time.Minute),
 		expectedMasterInteractions: 2 * 10 * 1, // no. of slaves * no. of clients * max interactions
 		expectedSlaveInteractions:  []int64{10, 10},
-	})
-}
-
-func TestKVStoreWebSocketsIntegrationWithTimeLimit(t *testing.T) {
-	runIntegrationTest(t, &testCase{
-		rawConfig:           kvstoreWebSocketsConfig,
-		maxInteractions:     -1,
-		maxTestTime:         time.Duration(2 * time.Second),
-		expectedMinTestTime: time.Duration(2 * time.Second),
 	})
 }
 

--- a/pkg/loadtest/outagesim.go
+++ b/pkg/loadtest/outagesim.go
@@ -1,0 +1,306 @@
+package loadtest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultOutageSimTimeout is the default timeout before considering a request
+// to the outage simulator on a particular node to have failed.
+const DefaultOutageSimTimeout = time.Duration(3 * time.Second)
+
+// NodeStatus allows us to model whether a node is up or down.
+type NodeStatus string
+
+// The various states in which a node can be, in relation to the outage
+// simulator.
+const (
+	NodeUp   NodeStatus = "up"
+	NodeDown NodeStatus = "down"
+)
+
+// OutageSimulator is a client for interacting with tm-outage-sim-server on
+// behalf of one or more target network nodes.
+type OutageSimulator struct {
+	nodes map[string]*NodeOutageSimulator
+}
+
+// NodeOutageSimulator is a client for interacting with tm-outage-sim-server on
+// behalf of a single target network node.
+type NodeOutageSimulator struct {
+	statusUpdates *NodeStatusUpdate // The first status update in the linked list.
+	donec         chan struct{}     // Closed when this node's outage simulation is complete.
+}
+
+// NodeStatusUpdate is a linked list that keeps track of a wait time and the
+// desired node status at the end of that wait time. It also keeps track of the
+// next outage to be executed after this one.
+type NodeStatusUpdate struct {
+	Wait   time.Duration
+	Status NodeStatus
+	Next   *NodeStatusUpdate // The status update to be executed after this one.
+
+	client       *http.Client // An HTTP client with which to make the requests.
+	outageSimURL *url.URL     // The URL to which to make this status update.
+	username     string
+	password     string
+	cancelc      chan struct{} // Closed when this update needs to be cancelled.
+	donec        chan struct{} // Closed if this is the final update in a chain and it terminates.
+}
+
+//
+// OutageSimulator
+//
+
+// NewOutageSimulator constructs an outage simulator for multiple test targets.
+func NewOutageSimulator(plan, username, password string, nodeURLs map[string]string) (*OutageSimulator, error) {
+	nodePlans, err := parseOutagePlan(plan)
+	if err != nil {
+		return nil, err
+	}
+	nodes := make(map[string]*NodeOutageSimulator)
+	for moniker, nodePlan := range nodePlans {
+		nodeURL, exists := nodeURLs[moniker]
+		if !exists {
+			return nil, fmt.Errorf("unrecognized node moniker in outage simulation plan: %s", moniker)
+		}
+		outageSimURL, err := url.Parse(nodeURL)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse outage simulator URL for target %s: %v", moniker, err)
+		}
+		nodes[moniker], err = NewNodeOutageSimulator(outageSimURL, username, password, nodePlan)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return &OutageSimulator{
+		nodes: nodes,
+	}, nil
+}
+
+// Start kicks off the outage simulator, and provides feedback via the given
+// error channel.
+func (s *OutageSimulator) Start(errc chan error) {
+	for _, node := range s.nodes {
+		node.Start(errc)
+	}
+}
+
+// Wait blocks the current goroutine until all of the nodes' update chains have
+// terminated.
+func (s *OutageSimulator) Wait() {
+	for _, node := range s.nodes {
+		node.Wait()
+	}
+}
+
+// Parses the given plan into a map of node IDs to node-specific outage plans.
+// The plan format looks like the following:
+//
+//    <node_moniker>=<wait_duration>:<status>,<wait_duration>:<status>,...
+//    node1=3m:down,8m:up,2m:down,30s:up
+//    node2=1m:down,12m:up,3m:down,10s:up
+//
+func parseOutagePlan(plan string) (nodePlan map[string]string, err error) {
+	nodePlan = make(map[string]string)
+	lines := strings.Split(plan, "\n")
+	for lineNo, line := range lines {
+		tline := strings.Trim(line, " \r\n\t")
+		if len(tline) > 0 {
+			parts := strings.Split(tline, "=")
+			if len(parts) != 2 {
+				err = fmt.Errorf("syntax error on line %d of outage plan configuration", lineNo)
+				return
+			}
+			tmoniker, tnodePlan := strings.Trim(parts[0], " \t"), strings.Trim(parts[1], " \t")
+			if len(tmoniker) == 0 {
+				err = fmt.Errorf("syntax error on line %d of outage plan configuration: missing moniker", lineNo)
+				return
+			}
+			if len(tnodePlan) == 0 {
+				err = fmt.Errorf("syntax error on line %d of outage plan configuration: missing node plan", lineNo)
+				return
+			}
+			if _, exists := nodePlan[tmoniker]; exists {
+				err = fmt.Errorf("syntax error on line %d of outage plan configuration: duplicate node plan for moniker \"%s\"", lineNo, tmoniker)
+				return
+			}
+			nodePlan[tmoniker] = tnodePlan
+		}
+	}
+	return
+}
+
+//
+// NodeOutageSimulator
+//
+
+// NewNodeOutageSimulator parses the given plan to produce either a single-node
+// outage simulator, or an error on failure.
+func NewNodeOutageSimulator(outageSimURL *url.URL, username, password, plan string) (*NodeOutageSimulator, error) {
+	var curUpdate *NodeStatusUpdate
+	lastStatus := NodeUp
+	sim := &NodeOutageSimulator{
+		donec: make(chan struct{}),
+	}
+	client := &http.Client{Timeout: DefaultOutageSimTimeout}
+
+	statusUpdates := strings.Split(plan, ",")
+	for i, statusUpdate := range statusUpdates {
+		wait, newStatus, err := parseNodeOutagePlan(statusUpdate)
+		if err != nil {
+			return nil, fmt.Errorf("error in outage %d: %v", i, err)
+		}
+		if i > 0 && newStatus == lastStatus {
+			return nil, fmt.Errorf("error in outage %d: status is same as previous status", i)
+		}
+		lastStatus = newStatus
+
+		newUpdate := NewNodeStatusUpdate(client, outageSimURL, username, password, wait, newStatus, sim.donec)
+		if curUpdate == nil {
+			curUpdate = newUpdate
+			sim.statusUpdates = curUpdate
+		} else {
+			curUpdate.Next = newUpdate
+			// advance our cursor in the linked list
+			curUpdate = curUpdate.Next
+		}
+	}
+	return sim, nil
+}
+
+func parseNodeOutagePlan(plan string) (wait time.Duration, newStatus NodeStatus, err error) {
+	parts := strings.Split(strings.Trim(plan, " "), ":")
+	if len(parts) != 2 {
+		err = fmt.Errorf("expecting a time and a status separated by a single colon")
+		return
+	}
+	wait, err = time.ParseDuration(parts[0])
+	if err != nil {
+		err = fmt.Errorf("%v", err)
+		return
+	}
+	if parts[1] != string(NodeUp) && parts[1] != string(NodeDown) {
+		err = fmt.Errorf("expecting either \"%s\" or \"%s\"", NodeUp, NodeDown)
+		return
+	}
+	newStatus = NodeStatus(parts[1])
+	return
+}
+
+// Start kicks off the chain of outage instructions. If an error occurs, the
+// chain's execution will be terminated and the error will be returned through
+// the given channel.
+func (s *NodeOutageSimulator) Start(errc chan error) {
+	if s.statusUpdates != nil {
+		s.statusUpdates.Start(errc)
+	}
+}
+
+// Cancel will cancel all of this node's status updates immediately, preventing
+// any future ones from completing.
+func (s *NodeOutageSimulator) Cancel() {
+	if s.statusUpdates != nil {
+		s.statusUpdates.Cancel()
+	}
+}
+
+// Wait will wait until the node outage simulator's update chain completes.
+func (s *NodeOutageSimulator) Wait() {
+	if s.statusUpdates != nil {
+		s.statusUpdates.Join()
+	}
+}
+
+//
+// NodeStatusUpdate
+//
+
+// NewNodeStatusUpdate constructs an outage from the given parameters.
+func NewNodeStatusUpdate(
+	client *http.Client,
+	outageSimURL *url.URL,
+	username, password string,
+	wait time.Duration,
+	status NodeStatus,
+	donec chan struct{},
+) *NodeStatusUpdate {
+
+	return &NodeStatusUpdate{
+		Wait:         wait,
+		Status:       status,
+		client:       client,
+		outageSimURL: outageSimURL,
+		username:     username,
+		password:     password,
+		cancelc:      make(chan struct{}),
+		donec:        donec,
+	}
+}
+
+// Start will kick off the chain of updates from this one onwards, sequentially.
+func (u *NodeStatusUpdate) Start(errc chan error) {
+	go func() {
+		defer close(u.donec)
+		update := u
+		for update != nil {
+			if err := update.waitAndExecute(); err != nil {
+				errc <- err
+				return
+			}
+			update = update.Next
+		}
+	}()
+}
+
+// Cancel will cancel this particular update, and will cascade the cancellations
+// to all subsequent updates.
+func (u *NodeStatusUpdate) Cancel() {
+	close(u.cancelc)
+	// cascade the cancellation
+	if u.Next != nil {
+		u.Next.Cancel()
+	}
+}
+
+// Join will pause the current goroutine until either the status update chain
+// completes.
+func (u *NodeStatusUpdate) Join() {
+	<-u.donec
+}
+
+func (u *NodeStatusUpdate) waitAndExecute() (err error) {
+	ticker := time.NewTicker(u.Wait)
+	defer ticker.Stop()
+	select {
+	case <-ticker.C:
+		err = u.execute()
+		return
+
+	case <-u.cancelc:
+		return
+	}
+}
+
+func (u *NodeStatusUpdate) execute() (err error) {
+	req, err := http.NewRequest("POST", u.outageSimURL.String(), strings.NewReader(string(u.Status)))
+	if err != nil {
+		return
+	}
+	defer req.Body.Close()
+	req.SetBasicAuth(u.username, u.password)
+	res, err := u.client.Do(req)
+	if err != nil {
+		return
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(res.Body)
+		return fmt.Errorf("request to outage simulator failed with status code %d: %s", res.StatusCode, string(body))
+	}
+	return
+}

--- a/pkg/loadtest/outagesim_test.go
+++ b/pkg/loadtest/outagesim_test.go
@@ -1,6 +1,7 @@
 package loadtest_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -15,50 +16,60 @@ const (
 	testOutageSimPassword = "testpassword"
 )
 
-type testOutageResult struct {
+type outageSimTestCase struct {
+	plan                  string
+	user                  string
+	password              string
+	expectSyntaxError     bool
+	expectRequestFailures bool
+	expectedNode1Results  []outageSimTestResult
+	expectedNode2Results  []outageSimTestResult
+}
+
+type outageSimTestResult struct {
 	code       int
 	nodeStatus loadtest.NodeStatus
 }
 
-func makeOutageSimHandler(resultc chan testOutageResult) func(w http.ResponseWriter, r *http.Request) {
+func makeOutageSimHandler(resultc chan outageSimTestResult) func(w http.ResponseWriter, r *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		u, p, _ := r.BasicAuth()
 		if u != testOutageSimUser || p != testOutageSimPassword {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
-			resultc <- testOutageResult{code: http.StatusUnauthorized}
+			resultc <- outageSimTestResult{code: http.StatusUnauthorized}
 			return
 		}
 		if r.Method != "POST" {
 			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
-			resultc <- testOutageResult{code: http.StatusMethodNotAllowed}
+			resultc <- outageSimTestResult{code: http.StatusMethodNotAllowed}
 			return
 		}
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
-			resultc <- testOutageResult{code: http.StatusInternalServerError}
+			resultc <- outageSimTestResult{code: http.StatusInternalServerError}
 			return
 		}
 		switch string(body) {
 		case string(loadtest.NodeUp), string(loadtest.NodeDown):
 			w.WriteHeader(http.StatusOK)
-			resultc <- testOutageResult{code: http.StatusOK, nodeStatus: loadtest.NodeStatus(string(body))}
+			resultc <- outageSimTestResult{code: http.StatusOK, nodeStatus: loadtest.NodeStatus(string(body))}
 
 		default:
 			http.Error(w, "Invalid request", http.StatusBadRequest)
-			resultc <- testOutageResult{code: http.StatusBadRequest}
+			resultc <- outageSimTestResult{code: http.StatusBadRequest}
 		}
 	}
 }
 
-func TestOutageSimulatorHappyPath(t *testing.T) {
-	ts1resultc := make(chan testOutageResult, 1)
+func TestOutageSimulator(t *testing.T) {
+	ts1resultc := make(chan outageSimTestResult, 1)
 	mux1 := http.NewServeMux()
 	mux1.HandleFunc("/", makeOutageSimHandler(ts1resultc))
 	ts1 := httptest.NewServer(mux1)
 	defer ts1.Close()
 
-	ts2resultc := make(chan testOutageResult, 1)
+	ts2resultc := make(chan outageSimTestResult, 1)
 	mux2 := http.NewServeMux()
 	mux2.HandleFunc("/", makeOutageSimHandler(ts2resultc))
 	ts2 := httptest.NewServer(mux2)
@@ -68,81 +79,151 @@ func TestOutageSimulatorHappyPath(t *testing.T) {
 		"node1": ts1.URL,
 		"node2": ts2.URL,
 	}
-	sim, err := loadtest.NewOutageSimulator(
-		`
-			node1=10ms:down,5ms:up,25ms:down
-			node2=5ms:down,30ms:up
-		`,
-		testOutageSimUser,
-		testOutageSimPassword,
-		nodeURLs,
-	)
-	if err != nil {
-		t.Fatal(err)
+
+	testCases := []outageSimTestCase{
+		// 0
+		outageSimTestCase{
+			plan: `
+				node1=10ms:down,5ms:up,25ms:down
+				node2=5ms:down,30ms:up
+			`,
+			user:     testOutageSimUser,
+			password: testOutageSimPassword,
+			expectedNode1Results: []outageSimTestResult{
+				outageSimTestResult{
+					code:       http.StatusOK,
+					nodeStatus: loadtest.NodeDown,
+				},
+				outageSimTestResult{
+					code:       http.StatusOK,
+					nodeStatus: loadtest.NodeUp,
+				},
+				outageSimTestResult{
+					code:       http.StatusOK,
+					nodeStatus: loadtest.NodeDown,
+				},
+			},
+			expectedNode2Results: []outageSimTestResult{
+				outageSimTestResult{
+					code:       http.StatusOK,
+					nodeStatus: loadtest.NodeDown,
+				},
+				outageSimTestResult{
+					code:       http.StatusOK,
+					nodeStatus: loadtest.NodeUp,
+				},
+			},
+		},
+		// 1
+		outageSimTestCase{
+			plan: `
+				node1=10ms:down,5ms:up
+			`,
+			user:     testOutageSimUser,
+			password: testOutageSimPassword,
+			expectedNode1Results: []outageSimTestResult{
+				outageSimTestResult{
+					code:       http.StatusOK,
+					nodeStatus: loadtest.NodeDown,
+				},
+				outageSimTestResult{
+					code:       http.StatusOK,
+					nodeStatus: loadtest.NodeUp,
+				},
+			},
+			expectedNode2Results: []outageSimTestResult{},
+		},
+		// 2
+		outageSimTestCase{
+			plan: `
+				node1=10ms:down,5ms:up node2=10ms:down,5ms:up
+			`,
+			expectSyntaxError: true,
+		},
+		// 3
+		outageSimTestCase{
+			plan: `
+				node1=node2=10ms:down,5ms:up
+			`,
+			expectSyntaxError: true,
+		},
+		// 4
+		outageSimTestCase{
+			plan: `
+				node1=10ms:down,5ms:up,25ms:down
+				node2=5ms:down,30ms:up
+			`,
+			user:                  testOutageSimUser,
+			password:              "wrongpassword",
+			expectRequestFailures: true,
+			expectedNode1Results: []outageSimTestResult{
+				outageSimTestResult{
+					code: http.StatusUnauthorized,
+				},
+			},
+			expectedNode2Results: []outageSimTestResult{
+				outageSimTestResult{
+					code: http.StatusUnauthorized,
+				},
+			},
+		},
 	}
-	errc := make(chan error, 1)
-	sim.Start(errc)
 
-	node1Results := make([]testOutageResult, 0)
-	node2Results := make([]testOutageResult, 0)
-waitLoop:
-	for {
-		select {
-		case err := <-errc:
-			t.Fatal(err)
-
-		case r := <-ts1resultc:
-			node1Results = append(node1Results, r)
-			if len(node1Results) == 3 && len(node2Results) == 2 {
-				break waitLoop
+testCaseLoop:
+	for i, tc := range testCases {
+		sim, err := loadtest.NewOutageSimulator(
+			tc.plan,
+			tc.user,
+			tc.password,
+			nodeURLs,
+		)
+		if err != nil {
+			if tc.expectSyntaxError {
+				continue testCaseLoop
 			}
-
-		case r := <-ts2resultc:
-			node2Results = append(node2Results, r)
-			if len(node1Results) == 3 && len(node2Results) == 2 {
-				break waitLoop
-			}
-
-		case <-time.After(1 * time.Second):
-			t.Fatal("test timed out")
+			t.Fatalf("test case %d: %v", i, err)
 		}
-	}
-	sim.Wait()
+		errc := make(chan error, 1)
+		sim.Start(errc)
 
-	expectedNode1Results := []testOutageResult{
-		testOutageResult{
-			code:       http.StatusOK,
-			nodeStatus: loadtest.NodeDown,
-		},
-		testOutageResult{
-			code:       http.StatusOK,
-			nodeStatus: loadtest.NodeUp,
-		},
-		testOutageResult{
-			code:       http.StatusOK,
-			nodeStatus: loadtest.NodeDown,
-		},
-	}
-	expectedNode2Results := []testOutageResult{
-		testOutageResult{
-			code:       http.StatusOK,
-			nodeStatus: loadtest.NodeDown,
-		},
-		testOutageResult{
-			code:       http.StatusOK,
-			nodeStatus: loadtest.NodeUp,
-		},
-	}
+		node1Results := make([]outageSimTestResult, 0)
+		node2Results := make([]outageSimTestResult, 0)
+	waitLoop:
+		for {
+			select {
+			case err := <-errc:
+				if !tc.expectRequestFailures {
+					t.Fatalf("test case %d: %v", i, err)
+				}
 
-	if !testOutageResultsEqual(expectedNode1Results, node1Results) {
-		t.Error("got node 1 results:", node1Results, "but expected:", expectedNode1Results)
-	}
-	if !testOutageResultsEqual(expectedNode2Results, node2Results) {
-		t.Error("got node 2 results:", node2Results, "but expected:", expectedNode2Results)
+			case r := <-ts1resultc:
+				node1Results = append(node1Results, r)
+				if len(node1Results) == len(tc.expectedNode1Results) && len(node2Results) == len(tc.expectedNode2Results) {
+					break waitLoop
+				}
+
+			case r := <-ts2resultc:
+				node2Results = append(node2Results, r)
+				if len(node1Results) == len(tc.expectedNode1Results) && len(node2Results) == len(tc.expectedNode2Results) {
+					break waitLoop
+				}
+
+			case <-time.After(1 * time.Second):
+				t.Fatalf("test case %d: test timed out", i)
+			}
+		}
+		sim.Wait()
+
+		if !testOutageResultsEqual(tc.expectedNode1Results, node1Results) {
+			t.Error(fmt.Sprintf("test case %d:", i), "got node 1 results:", node1Results, "but expected:", tc.expectedNode1Results)
+		}
+		if !testOutageResultsEqual(tc.expectedNode2Results, node2Results) {
+			t.Error(fmt.Sprintf("test case %d:", i), "got node 2 results:", node2Results, "but expected:", tc.expectedNode2Results)
+		}
 	}
 }
 
-func testOutageResultsEqual(expected, actual []testOutageResult) bool {
+func testOutageResultsEqual(expected, actual []outageSimTestResult) bool {
 	if len(expected) != len(actual) {
 		return false
 	}

--- a/pkg/loadtest/outagesim_test.go
+++ b/pkg/loadtest/outagesim_test.go
@@ -62,17 +62,18 @@ func makeOutageSimHandler(resultc chan outageSimTestResult) func(w http.Response
 	}
 }
 
+func makeOutageSimServer() (*httptest.Server, chan outageSimTestResult) {
+	resultc := make(chan outageSimTestResult, 1)
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", makeOutageSimHandler(resultc))
+	return httptest.NewServer(mux), resultc
+}
+
 func TestOutageSimulator(t *testing.T) {
-	ts1resultc := make(chan outageSimTestResult, 1)
-	mux1 := http.NewServeMux()
-	mux1.HandleFunc("/", makeOutageSimHandler(ts1resultc))
-	ts1 := httptest.NewServer(mux1)
+	ts1, ts1resultc := makeOutageSimServer()
 	defer ts1.Close()
 
-	ts2resultc := make(chan outageSimTestResult, 1)
-	mux2 := http.NewServeMux()
-	mux2.HandleFunc("/", makeOutageSimHandler(ts2resultc))
-	ts2 := httptest.NewServer(mux2)
+	ts2, ts2resultc := makeOutageSimServer()
 	defer ts2.Close()
 
 	nodeURLs := map[string]string{

--- a/pkg/loadtest/outagesim_test.go
+++ b/pkg/loadtest/outagesim_test.go
@@ -1,0 +1,158 @@
+package loadtest_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/interchainio/tm-load-test/pkg/loadtest"
+)
+
+const (
+	testOutageSimUser     = "testuser"
+	testOutageSimPassword = "testpassword"
+)
+
+type testOutageResult struct {
+	code       int
+	nodeStatus loadtest.NodeStatus
+}
+
+func makeOutageSimHandler(resultc chan testOutageResult) func(w http.ResponseWriter, r *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		u, p, _ := r.BasicAuth()
+		if u != testOutageSimUser || p != testOutageSimPassword {
+			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			resultc <- testOutageResult{code: http.StatusUnauthorized}
+			return
+		}
+		if r.Method != "POST" {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			resultc <- testOutageResult{code: http.StatusMethodNotAllowed}
+			return
+		}
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			resultc <- testOutageResult{code: http.StatusInternalServerError}
+			return
+		}
+		switch string(body) {
+		case string(loadtest.NodeUp), string(loadtest.NodeDown):
+			w.WriteHeader(http.StatusOK)
+			resultc <- testOutageResult{code: http.StatusOK, nodeStatus: loadtest.NodeStatus(string(body))}
+
+		default:
+			http.Error(w, "Invalid request", http.StatusBadRequest)
+			resultc <- testOutageResult{code: http.StatusBadRequest}
+		}
+	}
+}
+
+func TestOutageSimulatorHappyPath(t *testing.T) {
+	ts1resultc := make(chan testOutageResult, 1)
+	mux1 := http.NewServeMux()
+	mux1.HandleFunc("/", makeOutageSimHandler(ts1resultc))
+	ts1 := httptest.NewServer(mux1)
+	defer ts1.Close()
+
+	ts2resultc := make(chan testOutageResult, 1)
+	mux2 := http.NewServeMux()
+	mux2.HandleFunc("/", makeOutageSimHandler(ts2resultc))
+	ts2 := httptest.NewServer(mux2)
+	defer ts2.Close()
+
+	nodeURLs := map[string]string{
+		"node1": ts1.URL,
+		"node2": ts2.URL,
+	}
+	sim, err := loadtest.NewOutageSimulator(
+		`
+			node1=10ms:down,5ms:up,25ms:down
+			node2=5ms:down,30ms:up
+		`,
+		testOutageSimUser,
+		testOutageSimPassword,
+		nodeURLs,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	errc := make(chan error, 1)
+	sim.Start(errc)
+
+	node1Results := make([]testOutageResult, 0)
+	node2Results := make([]testOutageResult, 0)
+waitLoop:
+	for {
+		select {
+		case err := <-errc:
+			t.Fatal(err)
+
+		case r := <-ts1resultc:
+			node1Results = append(node1Results, r)
+			if len(node1Results) == 3 && len(node2Results) == 2 {
+				break waitLoop
+			}
+
+		case r := <-ts2resultc:
+			node2Results = append(node2Results, r)
+			if len(node1Results) == 3 && len(node2Results) == 2 {
+				break waitLoop
+			}
+
+		case <-time.After(1 * time.Second):
+			t.Fatal("test timed out")
+		}
+	}
+	sim.Wait()
+
+	expectedNode1Results := []testOutageResult{
+		testOutageResult{
+			code:       http.StatusOK,
+			nodeStatus: loadtest.NodeDown,
+		},
+		testOutageResult{
+			code:       http.StatusOK,
+			nodeStatus: loadtest.NodeUp,
+		},
+		testOutageResult{
+			code:       http.StatusOK,
+			nodeStatus: loadtest.NodeDown,
+		},
+	}
+	expectedNode2Results := []testOutageResult{
+		testOutageResult{
+			code:       http.StatusOK,
+			nodeStatus: loadtest.NodeDown,
+		},
+		testOutageResult{
+			code:       http.StatusOK,
+			nodeStatus: loadtest.NodeUp,
+		},
+	}
+
+	if !testOutageResultsEqual(expectedNode1Results, node1Results) {
+		t.Error("got node 1 results:", node1Results, "but expected:", expectedNode1Results)
+	}
+	if !testOutageResultsEqual(expectedNode2Results, node2Results) {
+		t.Error("got node 2 results:", node2Results, "but expected:", expectedNode2Results)
+	}
+}
+
+func testOutageResultsEqual(expected, actual []testOutageResult) bool {
+	if len(expected) != len(actual) {
+		return false
+	}
+
+	for i, e := range expected {
+		a := actual[i]
+		if e != a {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
This PR aims to introduce support for the outage simulator into the load testing tool, such that, while a load test is underway, the master load testing node can turn Tendermint network nodes on and off according to a predefined schedule.