### PR TITLE
Add example config for outage simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## v0.3.0
+* [\#15](https://github.com/interchainio/tm-load-test/pull/14) - Add example
+  configuration for outage simulation while load testing.
 * [\#14](https://github.com/interchainio/tm-load-test/pull/14) - Add support for
   the outage simulator from the master node during load testing.
 * [\#13](https://github.com/interchainio/tm-load-test/pull/13) - Add basic HTTP

--- a/examples/load-test-outage-sim.toml
+++ b/examples/load-test-outage-sim.toml
@@ -1,0 +1,141 @@
+[master]
+# The host IP/port to which to bind the master
+bind = "127.0.0.1:26670"
+
+# How many slaves to expect to connect before starting the load test
+expect_slaves = 2
+
+# How long to wait for slaves to connect before considering the load test a
+# failure (if not all slaves have connected within this time period)
+expect_slaves_within = "1m"
+
+# A time period to wait after successful completion of the load testing before
+# completely shutting the master down. This is useful in case one wants to allow
+# for external polling of the Prometheus stats endpoint after successful
+# completion of testing for a while.
+wait_after_finished = "10s"
+
+[slave]
+# The IP address/port to which to bind the slave node. Leave out the port to
+# pick a random port.
+bind = "127.0.0.1:"
+
+# HTTP address by which the master can be reached. If the master requires
+# authentication, include the username:password in the URL below. Alternatively,
+# include the username and password in the TMLOADTEST_MASTER_USERNAME and
+# TMLOADTEST_MASTER_PASSWORD environment variables when running the slave.
+master = "http://127.0.0.1:26670"
+
+# How long to keep polling for the master before considering the master to have
+# failed to start up at all.
+expect_master_within = "1m"
+
+# After being accepted by the master, this defines how long to keep polling the
+# master for a "GO!" message. After this period, the slave considers the whole
+# test a failure.
+expect_start_within = "1m"
+
+# A time period to wait after successful completion of the load testing before
+# completely shutting the slave down. This is useful in case one wants to allow
+# for external polling of the Prometheus stats endpoint after successful
+# completion of testing for a while.
+wait_after_finished = "10s"
+
+[test_network]
+
+    [test_network.autodetect]
+    # Set to true if you want the test network's nodes to be automatically
+    # detected from a single Tendermint node. The master will poll the
+    # seed_node for other peers to use as targets.
+    enabled = false
+
+    # If test_network.autodetect.enabled is set to true, this seed_node address
+    # will be used to try to obtain a list of targets for load testing.
+    seed_node = "http://192.168.2.1:26657"
+
+    # If test_network.autodetect.enabled is set to true, this is how many
+    # targets to expect prior to starting the load testing.
+    expect_targets = 3
+
+    # The maximum time to wait while polling the seed_node for the required
+    # number of targets before considering the entire load test a failure.
+    expect_targets_within = "3m"
+
+    # Whether or not to consider the seed node as part of the test network.
+    target_seed_node = false
+
+    # This array is only taken into account if test_network.autodetect.enabled
+    # is set to false.
+    [[test_network.targets]]
+    id = "node1"
+    url = "http://loadtest-node1:26657"
+
+    [[test_network.targets]]
+    id = "node2"
+    url = "http://loadtest-node2:26657"
+
+    [[test_network.targets]]
+    id = "node3"
+    url = "http://loadtest-node3:26657"
+
+    [[test_network.targets]]
+    id = "node4"
+    url = "http://loadtest-node4:26657"
+
+    [test_network.outage_sim]
+    # Enable the outage simulator
+    enabled = true
+
+    # Maximum length of outages: 2m30s
+    plan = """
+        node1=1m:down,1m:up
+        node4=2m:down,30s:up
+    """
+
+    # These parameters will be overridden by environment variables
+    username = "tm-load-test"
+    password = "password"
+
+[clients]
+# What type of client to spawn. The `kvstore-http` client will interact with the
+# `kvstore` ABCI application via the HTTP RPC on the nodes.
+type = "kvstore-http"
+
+# Additional parameters specific to this particular type of client.
+additional_params = ""
+
+# The number of clients to spawn per slave.
+spawn = 50
+
+# The rate at which new clients should be spawned on each slave, per second. A
+# value of 10 would mean that every second, 10 new clients will be spawned on
+# each slave. A value of 0.1 would mean that only 1 client will be spawned every
+# 10 seconds.
+spawn_rate = 10.0
+
+# The maximum number of interactions to send, per client. Set to -1 to make this
+# "infinite", but then the `max_test_time` parameter MUST be set.
+max_interactions = -1
+
+# After how long do we consider an interaction to have timed out?
+interaction_timeout = "11s"
+
+# The maximum amount of time to allow for load testing. If this is exceeded,
+# the test will gracefully be brought to an end.
+max_test_time = "4m"
+
+#
+# Request-related parameters
+#
+# Note: it is up to the particular client implementation to honour these
+# parameters.
+#
+
+# The maximum time to wait before each request in an interaction.
+request_wait_min = "0ms"
+
+# The minimum time to wait before request in an interaction.
+request_wait_max = "0ms"
+
+# After how long do we consider a request to have timed out?
+request_timeout = "5s"

--- a/pkg/loadtest/master.go
+++ b/pkg/loadtest/master.go
@@ -634,9 +634,14 @@ func (m *Master) unregisterReadySubscriber(id int) {
 }
 
 func (m *Master) startOutageSim() (err error) {
+	var targetURL *url.URL
 	nodeURLs := make(map[string]string)
 	for _, targetCfg := range m.getTargets() {
-		nodeURLs[targetCfg.ID] = targetCfg.URL
+		targetURL, err = url.Parse(targetCfg.URL)
+		if err != nil {
+			return
+		}
+		nodeURLs[targetCfg.ID] = fmt.Sprintf("%s://%s:%d", targetURL.Scheme, targetURL.Hostname(), m.cfg.TestNetwork.OutageSim.TargetPort)
 	}
 	m.outageSim, err = NewOutageSimulator(
 		m.cfg.TestNetwork.OutageSim.Plan,


### PR DESCRIPTION
This PR adds an example configuration file for outage simulation during load testing. It also fixes one or two minor issues relating to the outage simulator's configuration.