### PR TITLE
Add ability to wait for minimum connectivity

### DIFF
--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -62,6 +62,7 @@ func buildCLI(cli *CLIConfig, logger logging.Logger) *cobra.Command {
 	rootCmd.PersistentFlags().IntVar(&cfg.ExpectPeers, "expect-peers", 0, "The minimum number of peers to expect when crawling the P2P network from the specified endpoint(s) prior to waiting for slaves to connect")
 	rootCmd.PersistentFlags().IntVar(&cfg.MaxEndpoints, "max-endpoints", 0, "The maximum number of endpoints to use for testing, where 0 means unlimited")
 	rootCmd.PersistentFlags().IntVar(&cfg.PeerConnectTimeout, "peer-connect-timeout", 600, "The number of seconds to wait for all required peers to connect if expect-peers > 0")
+	rootCmd.PersistentFlags().IntVar(&cfg.MinConnectivity, "min-peer-connectivity", 0, "The minimum number of peers to which each peer must be connected before starting the load test")
 	rootCmd.PersistentFlags().BoolVarP(&flagVerbose, "verbose", "v", false, "Increase output logging verbosity to DEBUG level")
 
 	var masterCfg MasterConfig

--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	EndpointSelectMethod string   `json:"endpoint_select_method"` // The method by which to select endpoints for load testing.
 	ExpectPeers          int      `json:"expect_peers"`           // The minimum number of peers to expect before starting a load test. Set to 0 by default (no minimum).
 	MaxEndpoints         int      `json:"max_endpoints"`          // The maximum number of endpoints to use for load testing. Set to 0 by default (no maximum).
+	MinConnectivity      int      `json:"min_connectivity"`       // The minimum number of peers to which each peer must be connected before starting the load test. Set to 0 by default (no minimum).
 	PeerConnectTimeout   int      `json:"peer_connect_timeout"`   // The maximum time to wait (in seconds) for all peers to connect, if ExpectPeers > 0.
 }
 
@@ -98,6 +99,9 @@ func (c Config) Validate() error {
 	}
 	if c.MaxEndpoints < 0 {
 		return fmt.Errorf("invalid value for max-endpoints: %d", c.MaxEndpoints)
+	}
+	if c.MinConnectivity < 0 {
+		return fmt.Errorf("invalid value for min-peer-connectivity: %d", c.MinConnectivity)
 	}
 	return nil
 }

--- a/pkg/loadtest/loadtest.go
+++ b/pkg/loadtest/loadtest.go
@@ -15,6 +15,7 @@ func executeLoadTest(cfg Config) error {
 			cfg.Endpoints,
 			cfg.EndpointSelectMethod,
 			cfg.ExpectPeers,
+			cfg.MinConnectivity,
 			cfg.MaxEndpoints,
 			time.Duration(cfg.PeerConnectTimeout)*time.Second,
 			logger,


### PR DESCRIPTION
As per discussions, we need to be able to instruct `tm-load-test` to wait until a minimum degree of P2P connectivity is reached (i.e. the minimum number of peers of which any given peer knows).

This commit introduces this functionality through a `--min-peer-connectivity` command line switch.