### PR TITLE
Fix shutdown wait functionality

### DIFF
--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -160,7 +160,7 @@ func trapInterrupts(onKill func(), logger logging.Logger) chan struct{} {
 			logger.Info("Caught kill signal")
 			onKill()
 		case <-cancelTrap:
-			return
+			logger.Debug("Interrupt trap cancelled")
 		}
 	}()
 	return cancelTrap


### PR DESCRIPTION
The shutdown wait functionality was not working correctly and one couldn't cancel it previously, but now this commit fixes that.