### PR TITLE
Fix tx average rate calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.6.2
+* [\#37](https://github.com/interchainio/tm-load-test/pull/37) - Fix average
+  transaction throughput rate in reporting/metrics.
+
 ## v0.6.1
 * [\#35](https://github.com/interchainio/tm-load-test/pull/35) - Minor fix for
   broken shutdown-wait functionality.

--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CLIVersion must be manually updated as new versions are released.
-const CLIVersion = "v0.6.1"
+const CLIVersion = "v0.6.2"
 
 // cliVersionCommitID must be set through linker settings. See
 // https://stackoverflow.com/a/11355611/1156132 for details.

--- a/pkg/loadtest/master.go
+++ b/pkg/loadtest/master.go
@@ -354,6 +354,7 @@ func (m *Master) logTestingProgress() {
 	)
 
 	m.lastProgressUpdate = time.Now()
+	m.totalTxs = totalTxs
 	m.totalTxsMetric.Set(float64(totalTxs))
 	m.txRateMetric.Set(avgRate)
 	m.overallTxRateMetric.Set(overallAvgRate)


### PR DESCRIPTION
Right now the periodically reported average tx throughput rate calculation is broken because I forgot to track the previous total number of txs. This PR fixes that, and bumps the minor version for `tm-load-test`.