### PR TITLE
Expose load test ID Prometheus gauge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Changelog
 
+## v0.8.0
+* [\#42](https://github.com/interchainio/tm-load-test/pull/42) - Add Prometheus
+  gauge for when load test is underway. This indicator exposes a customizable
+  load test ID.
+
+## v0.7.1
+* Re-released due to v0.7.0 being incorrectly tagged
+
 ## v0.7.0
-* [\#39](https://github.com/interchainio/tm-load-test/issues/39) - Add basic
+* [\#39](https://github.com/interchainio/tm-load-test/pull/40) - Add basic
   aggregate statistics output to CSV file.
 * Added integration test for standalone execution happy path.
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ The following kinds of metrics are made available here:
   * 5 = Slave completed load testing successfully
 * Standard Prometheus-provided metrics about the garbage collector in 
   `tm-load-test`
+* The ID of the load test currently underway (defaults to 0), set by way of the
+  `--load-test-id` flag on the master
 
 ## Aggregate Statistics
 As of `tm-load-test` v0.7.0, one can now write simple aggregate statistics to

--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -91,6 +91,7 @@ func buildCLI(cli *CLIConfig, logger logging.Logger) *cobra.Command {
 	masterCmd.PersistentFlags().IntVar(&masterCfg.ExpectSlaves, "expect-slaves", 2, "The number of slaves to expect to connect to the master before starting load testing")
 	masterCmd.PersistentFlags().IntVar(&masterCfg.SlaveConnectTimeout, "connect-timeout", 180, "The maximum number of seconds to wait for all slaves to connect")
 	masterCmd.PersistentFlags().IntVar(&masterCfg.ShutdownWait, "shutdown-wait", 0, "The number of seconds to wait after testing completes prior to shutting down the web server")
+	masterCmd.PersistentFlags().IntVar(&masterCfg.LoadTestID, "load-test-id", 0, "The ID of the load test currently underway")
 
 	var slaveCfg SlaveConfig
 	slaveCmd := &cobra.Command{

--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CLIVersion must be manually updated as new versions are released.
-const CLIVersion = "v0.7.0"
+const CLIVersion = "v0.8.0"
 
 // cliVersionCommitID must be set through linker settings. See
 // https://stackoverflow.com/a/11355611/1156132 for details.

--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -44,6 +44,7 @@ type MasterConfig struct {
 	ExpectSlaves        int    `json:"expect_slaves"`   // The number of slaves to expect before starting the load test.
 	SlaveConnectTimeout int    `json:"connect_timeout"` // The number of seconds to wait for all slaves to connect.
 	ShutdownWait        int    `json:"shutdown_wait"`   // The number of seconds to wait at shutdown (while keeping the HTTP server running - primarily to allow Prometheus to keep polling).
+	LoadTestID          int    `json:"load_test_id"`    // An integer greater than 0 that will be exposed via a Prometheus gauge while the load test is underway.
 }
 
 // SlaveConfig is the configuration options specific to a slave node.
@@ -125,6 +126,9 @@ func (c MasterConfig) Validate() error {
 	}
 	if c.SlaveConnectTimeout < 1 {
 		return fmt.Errorf("master connect-timeout must be at least 1 second")
+	}
+	if c.LoadTestID < 0 {
+		return fmt.Errorf("master load-test-id must be 0 or greater")
 	}
 	return nil
 }


### PR DESCRIPTION
Addresses #41 

A gauge called `tmloadtest_master_test_underway` is added here, whose default value is **-1**.

When the load test is underway, its value changes to whatever `--load-test-id` is configured to (default = 0). When the load test finishes or fails, its value is changed back to **-1**.