### PR TITLE
Fix KVStore client transaction size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.8.1
+## v0.9.0
 * [\#47](https://github.com/interchainio/tm-load-test/pull/47) - Makes sure
   that the KVStore client's `GenerateTx` method honours the preconfigured
   transaction size. **NB: This involves a breaking API change!** Please see

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.8.1
+* [\#47](https://github.com/interchainio/tm-load-test/pull/47) - Makes sure
+  that the KVStore client's `GenerateTx` method honours the preconfigured
+  transaction size. **NB: This involves a breaking API change!** Please see
+  [the client API documentation](./pkg/loadtest/README.md) for more details.
+
 ## v0.8.0
 * [\#42](https://github.com/interchainio/tm-load-test/pull/42) - Add Prometheus
   gauge for when load test is underway. This indicator exposes a customizable

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ build-tm-outage-sim-server-linux:
 test:
 	go test -cover -race ./...
 
+bench:
+	go test -bench="Benchmark" -run="notests" ./...
+
 $(GOPATH)/bin/golangci-lint:
 	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ ABCI application running on that network. As such, the `tm-load-test` tool comes
 with built-in support for the `kvstore` ABCI application, but you can
 [build your own clients](./pkg/loadtest/README.md) for your own apps.
 
+**NB: `tm-load-test` is currently alpha-quality software. Semantic versioning is
+not strictly adhered to prior to a v1.0 release, so breaking API changes can
+emerge with minor version releases.**
+
 ## Requirements
 In order to build and use the tools, you will need:
 

--- a/pkg/loadtest/README.md
+++ b/pkg/loadtest/README.md
@@ -48,7 +48,13 @@ type MyABCIAppClient struct {}
 // MyABCIAppClient implements loadtest.Client
 var _ loadtest.Client = (*MyABCIAppClient)(nil)
 
-func (f *MyABCIAppClientFactory) NewClient() (loadtest.Client, error) {
+func (f *MyABCIAppClientFactory) ValidateConfig(cfg loadtest.Config) error {
+    // Do any checks here that you need to ensure that the load test 
+    // configuration is compatible with your client.
+    return nil
+}
+
+func (f *MyABCIAppClientFactory) NewClient(cfg loadtest.Config) (loadtest.Client, error) {
     return &MyABCIAppClient{}, nil
 }
 

--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CLIVersion must be manually updated as new versions are released.
-const CLIVersion = "v0.8.1"
+const CLIVersion = "v0.9.0"
 
 // cliVersionCommitID must be set through linker settings. See
 // https://stackoverflow.com/a/11355611/1156132 for details.

--- a/pkg/loadtest/cli.go
+++ b/pkg/loadtest/cli.go
@@ -12,7 +12,7 @@ import (
 )
 
 // CLIVersion must be manually updated as new versions are released.
-const CLIVersion = "v0.8.0"
+const CLIVersion = "v0.8.1"
 
 // cliVersionCommitID must be set through linker settings. See
 // https://stackoverflow.com/a/11355611/1156132 for details.

--- a/pkg/loadtest/client.go
+++ b/pkg/loadtest/client.go
@@ -4,9 +4,13 @@ import "fmt"
 
 // ClientFactory produces load testing clients.
 type ClientFactory interface {
+	// ValidateConfig must check whether the given configuration is valid for
+	// our specific client factory.
+	ValidateConfig(cfg Config) error
+
 	// NewClient must instantiate a new load testing client, or produce an error
 	// if that process fails.
-	NewClient() (Client, error)
+	NewClient(cfg Config) (Client, error)
 }
 
 // Client generates transactions to be sent to a specific endpoint.

--- a/pkg/loadtest/client_kvstore.go
+++ b/pkg/loadtest/client_kvstore.go
@@ -1,28 +1,55 @@
 package loadtest
 
 import (
-	"encoding/binary"
 	"fmt"
-	"sync"
 
 	"github.com/tendermint/tendermint/libs/common"
 )
 
-const minKVStoreTxSize int = 40
+// The Tendermint common.RandStr method can effectively generate human-readable
+// (alphanumeric) strings from a set of 62 characters. We aim here with the
+// KVStore client to generate unique client IDs as well as totally unique keys
+// for all transactions. Values are not so important.
+const KVStoreClientIDLen int = 5 // Allows for 6,471,002 random client IDs (62C5)
+const kvstoreMinValueLen int = 1 // We at least need 1 character in a key/value pair's value.
+
+// This is a map of nCr where n=62 and r varies from 0 through 15. It gives the
+// maximum number of unique transaction IDs that can be accommodated with a
+// given key suffix length.
+var kvstoreMaxTxsByKeySuffixLen = []uint64{
+	0,              // 0
+	62,             // 1
+	1891,           // 2
+	37820,          // 3
+	557845,         // 4
+	6471002,        // 5
+	61474519,       // 6
+	491796152,      // 7
+	3381098545,     // 8
+	20286591270,    // 9
+	107518933731,   // 10
+	508271323092,   // 11
+	2160153123141,  // 12
+	8308281242850,  // 13
+	29078984349975, // 14
+	93052749919920, // 15
+}
 
 // KVStoreClientFactory creates load testing clients to interact with the
 // built-in Tendermint kvstore ABCI application.
-type KVStoreClientFactory struct {
-	mtx         sync.Mutex
-	clientCount uint32
-}
+type KVStoreClientFactory struct{}
 
 // KVStoreClient generates arbitrary transactions (random key=value pairs) to
-// be sent to the kvstore ABCI application.
+// be sent to the kvstore ABCI application. The keys are structured as follows:
+//
+// `[client_id][tx_id]=[tx_id]`
+//
+// where each value (`client_id` and `tx_id`) is padded with 0s to meet the
+// transaction size requirement.
 type KVStoreClient struct {
-	keyPrefix []byte
-	keyLen    int
-	valueLen  int
+	keyPrefix    []byte // Contains the client ID
+	keySuffixLen int
+	valueLen     int
 }
 
 var _ ClientFactory = (*KVStoreClientFactory)(nil)
@@ -39,41 +66,53 @@ func NewKVStoreClientFactory() *KVStoreClientFactory {
 }
 
 func (f *KVStoreClientFactory) ValidateConfig(cfg Config) error {
-	// this will ensure that the key length is at least 19 bytes (4 bytes for
-	// the client ID, and another 15 random bytes)
-	if cfg.Size < minKVStoreTxSize {
-		return fmt.Errorf("transaction size must be at least %d bytes", minKVStoreTxSize)
+	maxTxsPerEndpoint := cfg.MaxTxsPerEndpoint()
+	if maxTxsPerEndpoint < 1 {
+		return fmt.Errorf("cannot calculate an appropriate maximum number of transactions per endpoint (got %d)", maxTxsPerEndpoint)
+	}
+	minKeySuffixLen, err := requiredKVStoreSuffixLen(maxTxsPerEndpoint)
+	if err != nil {
+		return err
+	}
+	// "[client_id][random_suffix]=[value]"
+	minTxSize := KVStoreClientIDLen + minKeySuffixLen + 1 + kvstoreMinValueLen
+	if cfg.Size < minTxSize {
+		return fmt.Errorf("transaction size %d is too small for given parameters (should be at least %d bytes)", cfg.Size, minTxSize)
 	}
 	return nil
 }
 
 func (f *KVStoreClientFactory) NewClient(cfg Config) (Client, error) {
-	// calculate how long each key/value pair must be to facilitate the
-	// configured transaction size
-	keyLen := (cfg.Size / 2) - 1
-	// we need to cater for the "=" symbol in between (minimum 20 bytes)
+	keyPrefix := []byte(common.RandStr(KVStoreClientIDLen))
+	keySuffixLen, err := requiredKVStoreSuffixLen(cfg.MaxTxsPerEndpoint())
+	if err != nil {
+		return nil, err
+	}
+	keyLen := len(keyPrefix) + keySuffixLen
+	// value length = key length - 1 (to cater for "=" symbol)
 	valueLen := cfg.Size - keyLen - 1
-	// subtract 4 bytes to make space for the client ID prefix
-	// TODO: Should we consider any alternative ways of constructing a key prefix?
-	keyPrefix := make([]byte, 4)
-	binary.LittleEndian.PutUint32(keyPrefix, f.nextClientID())
-	keyLen -= 4
 	return &KVStoreClient{
-		keyPrefix: keyPrefix,
-		keyLen:    keyLen,
-		valueLen:  valueLen,
+		keyPrefix:    keyPrefix,
+		keySuffixLen: keySuffixLen,
+		valueLen:     valueLen,
 	}, nil
 }
 
-func (f *KVStoreClientFactory) nextClientID() uint32 {
-	f.mtx.Lock()
-	defer f.mtx.Unlock()
-	f.clientCount += 1
-	return f.clientCount - 1
+func requiredKVStoreSuffixLen(maxTxCount uint64) (int, error) {
+	for l, maxTxs := range kvstoreMaxTxsByKeySuffixLen {
+		if maxTxCount < maxTxs {
+			if l+1 > len(kvstoreMaxTxsByKeySuffixLen) {
+				return -1, fmt.Errorf("cannot cater for maximum tx count of %d (too many unique transactions, suffix length %d)", maxTxCount, l+1)
+			}
+			// we use l+1 to minimize collision probability
+			return l + 1, nil
+		}
+	}
+	return -1, fmt.Errorf("cannot cater for maximum tx count of %d (too many unique transactions)", maxTxCount)
 }
 
 func (c *KVStoreClient) GenerateTx() ([]byte, error) {
-	k := append(c.keyPrefix, []byte(common.RandStr(c.keyLen))...)
+	k := append(c.keyPrefix, []byte(common.RandStr(c.keySuffixLen))...)
 	v := []byte(common.RandStr(c.valueLen))
 	return append(k, append([]byte("="), v...)...), nil
 }

--- a/pkg/loadtest/client_kvstore.go
+++ b/pkg/loadtest/client_kvstore.go
@@ -39,7 +39,7 @@ func NewKVStoreClientFactory() *KVStoreClientFactory {
 }
 
 func (f *KVStoreClientFactory) ValidateConfig(cfg Config) error {
-	// this will ensure that the key length is at least 20 bytes (4 bytes for
+	// this will ensure that the key length is at least 19 bytes (4 bytes for
 	// the client ID, and another 15 random bytes)
 	if cfg.Size < minKVStoreTxSize {
 		return fmt.Errorf("transaction size must be at least %d bytes", minKVStoreTxSize)
@@ -49,10 +49,12 @@ func (f *KVStoreClientFactory) ValidateConfig(cfg Config) error {
 
 func (f *KVStoreClientFactory) NewClient(cfg Config) (Client, error) {
 	// calculate how long each key/value pair must be to facilitate the
-	// configured transaction size (minimum 19 bytes)
+	// configured transaction size
 	keyLen := (cfg.Size / 2) - 1
 	// we need to cater for the "=" symbol in between (minimum 20 bytes)
 	valueLen := cfg.Size - keyLen - 1
+	// subtract 4 bytes to make space for the client ID prefix
+	// TODO: Should we consider any alternative ways of constructing a key prefix?
 	keyPrefix := make([]byte, 4)
 	binary.LittleEndian.PutUint32(keyPrefix, f.nextClientID())
 	keyLen -= 4

--- a/pkg/loadtest/client_kvstore.go
+++ b/pkg/loadtest/client_kvstore.go
@@ -1,14 +1,29 @@
 package loadtest
 
-import "github.com/tendermint/tendermint/libs/common"
+import (
+	"encoding/binary"
+	"fmt"
+	"sync"
+
+	"github.com/tendermint/tendermint/libs/common"
+)
+
+const minKVStoreTxSize int = 40
 
 // KVStoreClientFactory creates load testing clients to interact with the
 // built-in Tendermint kvstore ABCI application.
-type KVStoreClientFactory struct{}
+type KVStoreClientFactory struct {
+	mtx         sync.Mutex
+	clientCount uint32
+}
 
 // KVStoreClient generates arbitrary transactions (random key=value pairs) to
 // be sent to the kvstore ABCI application.
-type KVStoreClient struct{}
+type KVStoreClient struct {
+	keyPrefix []byte
+	keyLen    int
+	valueLen  int
+}
 
 var _ ClientFactory = (*KVStoreClientFactory)(nil)
 var _ Client = (*KVStoreClient)(nil)
@@ -23,12 +38,40 @@ func NewKVStoreClientFactory() *KVStoreClientFactory {
 	return &KVStoreClientFactory{}
 }
 
-func (f *KVStoreClientFactory) NewClient() (Client, error) {
-	return &KVStoreClient{}, nil
+func (f *KVStoreClientFactory) ValidateConfig(cfg Config) error {
+	// this will ensure that the key length is at least 20 bytes (4 bytes for
+	// the client ID, and another 15 random bytes)
+	if cfg.Size < minKVStoreTxSize {
+		return fmt.Errorf("transaction size must be at least %d bytes", minKVStoreTxSize)
+	}
+	return nil
+}
+
+func (f *KVStoreClientFactory) NewClient(cfg Config) (Client, error) {
+	// calculate how long each key/value pair must be to facilitate the
+	// configured transaction size (minimum 19 bytes)
+	keyLen := (cfg.Size / 2) - 1
+	// we need to cater for the "=" symbol in between (minimum 20 bytes)
+	valueLen := cfg.Size - keyLen - 1
+	keyPrefix := make([]byte, 4)
+	binary.LittleEndian.PutUint32(keyPrefix, f.nextClientID())
+	keyLen -= 4
+	return &KVStoreClient{
+		keyPrefix: keyPrefix,
+		keyLen:    keyLen,
+		valueLen:  valueLen,
+	}, nil
+}
+
+func (f *KVStoreClientFactory) nextClientID() uint32 {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.clientCount += 1
+	return f.clientCount - 1
 }
 
 func (c *KVStoreClient) GenerateTx() ([]byte, error) {
-	k := []byte(common.RandStr(8))
-	v := []byte(common.RandStr(8))
+	k := append(c.keyPrefix, []byte(common.RandStr(c.keyLen))...)
+	v := []byte(common.RandStr(c.valueLen))
 	return append(k, append([]byte("="), v...)...), nil
 }

--- a/pkg/loadtest/client_kvstore_test.go
+++ b/pkg/loadtest/client_kvstore_test.go
@@ -1,0 +1,66 @@
+package loadtest_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/interchainio/tm-load-test/pkg/loadtest"
+)
+
+func TestKVStoreClientFactoryConfigValidation(t *testing.T) {
+	testCases := []struct {
+		config loadtest.Config
+		err    bool
+	}{
+		{loadtest.Config{Size: 30}, true},  // tx size is too small
+		{loadtest.Config{Size: 40}, false}, // tx size is just right
+		{loadtest.Config{Size: 100}, false},
+		{loadtest.Config{Size: 250}, false},
+	}
+	factory := loadtest.NewKVStoreClientFactory()
+	for i, tc := range testCases {
+		err := factory.ValidateConfig(tc.config)
+		// if we were supposed to get an error
+		if tc.err && err == nil {
+			t.Errorf("Expected an error from test case %d, but got nil", i)
+		} else if !tc.err && err != nil {
+			t.Errorf("Expected no error from test case %d, but got: %v", i, err)
+		}
+	}
+}
+
+func TestKVStoreClient(t *testing.T) {
+	testCases := []loadtest.Config {
+		{Size: 40},
+		{Size: 100},
+		{Size: 250},
+	}
+	factory := loadtest.NewKVStoreClientFactory()
+	clientCounter := uint32(0)
+	for i, tc := range testCases {
+		err := factory.ValidateConfig(tc)
+		if err != nil {
+			t.Errorf("Expected config from test case %d to validate, but failed: %v", i, err)
+		}
+
+		for c := uint32(0); c < 2; c++ {
+			client, err := factory.NewClient(tc)
+			if err != nil {
+				t.Errorf("Did not expect error in test case %d from factory.NewClient: %v", i, err)
+			}
+			tx, err := client.GenerateTx()
+			if err != nil {
+				t.Errorf("Did not expect error in test case %d from client %d's GenerateTx: %v", i, c, err)
+			}
+			if len(tx) != tc.Size {
+				t.Errorf("Expected transaction from client %d in test case %d to be %d bytes, but was %d bytes", c, i, tc.Size, len(tx))
+			}
+			// check that the client's 4-byte ID is embedded in the transaction
+			embeddedID := binary.LittleEndian.Uint32(tx[0:4])
+			if clientCounter != embeddedID {
+				t.Errorf("Expected transaction prefix from client %d in test case %d to be %d, but was %d", c, i, clientCounter, embeddedID)
+			}
+			clientCounter++
+		}
+	}
+}

--- a/pkg/loadtest/client_kvstore_test.go
+++ b/pkg/loadtest/client_kvstore_test.go
@@ -1,7 +1,6 @@
 package loadtest_test
 
 import (
-	"encoding/binary"
 	"testing"
 
 	"github.com/interchainio/tm-load-test/pkg/loadtest"
@@ -12,10 +11,25 @@ func TestKVStoreClientFactoryConfigValidation(t *testing.T) {
 		config loadtest.Config
 		err    bool
 	}{
-		{loadtest.Config{Size: 30}, true},  // tx size is too small
-		{loadtest.Config{Size: 40}, false}, // tx size is just right
-		{loadtest.Config{Size: 100}, false},
-		{loadtest.Config{Size: 250}, false},
+		{loadtest.Config{Size: 1, Rate: 1000, Time: 1000, Count: -1}, true},  // invalid tx size
+		{loadtest.Config{Size: 10, Rate: 1000, Time: 1000, Count: -1}, true}, // tx size is too small
+
+		{loadtest.Config{Size: 14, Rate: 1000, Time: 10000, Count: -1}, false}, // just right for parameters
+
+		{loadtest.Config{Size: 20, Rate: 1000, Time: 10, Count: -1}, false},   // 10k txs @ 20 bytes each
+		{loadtest.Config{Size: 20, Rate: 1000, Time: 100, Count: -1}, false},  // 100k txs @ 20 bytes each
+		{loadtest.Config{Size: 20, Rate: 1000, Time: 1000, Count: -1}, false}, // 1m txs @ 20 bytes each
+
+		{loadtest.Config{Size: 100, Rate: 1000, Time: 10, Count: -1}, false},
+		{loadtest.Config{Size: 100, Rate: 1000, Time: 100000, Count: -1}, false}, // 100m txs @ 100 bytes each
+
+		{loadtest.Config{Size: 250, Rate: 1000, Time: 10, Count: -1}, false},
+
+		{loadtest.Config{Size: 10240, Rate: 1000, Time: 10, Count: -1}, false},     // 10k txs @ 10kB each
+		{loadtest.Config{Size: 10240, Rate: 1000, Time: 100, Count: -1}, false},    // 100k txs @ 10kB each
+		{loadtest.Config{Size: 10240, Rate: 1000, Time: 1000, Count: -1}, false},   // 1m txs @ 10kB each
+		{loadtest.Config{Size: 10240, Rate: 1000, Time: 10000, Count: -1}, false},  // 10m txs @ 10kB each
+		{loadtest.Config{Size: 10240, Rate: 1000, Time: 100000, Count: -1}, false}, // 100m txs @ 10kB each
 	}
 	factory := loadtest.NewKVStoreClientFactory()
 	for i, tc := range testCases {
@@ -29,22 +43,73 @@ func TestKVStoreClientFactoryConfigValidation(t *testing.T) {
 	}
 }
 
+func benchmarkKVStoreClient_GenerateTx(b *testing.B, cfg loadtest.Config) {
+	cfg.Count = b.N
+	factory := loadtest.NewKVStoreClientFactory()
+	if err := factory.ValidateConfig(cfg); err != nil {
+		b.Errorf("Unexpected error from KVStoreClientFactory.ValidateConfig(): %v", err)
+	}
+	client, err := factory.NewClient(cfg)
+	if err != nil {
+		b.Errorf("Unexpected error from KVStoreClientFactory.NewClient(): %v", err)
+	}
+	for n := 0; n < b.N; n++ {
+		_, _ = client.GenerateTx()
+	}
+}
+
+func BenchmarkKVStoreClient_GenerateTx_32b(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 32})
+}
+
+func BenchmarkKVStoreClient_GenerateTx_64b(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 64})
+}
+
+func BenchmarkKVStoreClient_GenerateTx_128b(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 128})
+}
+
+func BenchmarkKVStoreClient_GenerateTx_256b(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 256})
+}
+
+func BenchmarkKVStoreClient_GenerateTx_512b(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 512})
+}
+
+func BenchmarkKVStoreClient_GenerateTx_1kB(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 1024})
+}
+
+func BenchmarkKVStoreClient_GenerateTx_10kB(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 10240})
+}
+
+func BenchmarkKVStoreClient_GenerateTx_100kB(b *testing.B) {
+	benchmarkKVStoreClient_GenerateTx(b, loadtest.Config{Size: 102400})
+}
+
 func TestKVStoreClient(t *testing.T) {
-	testCases := []loadtest.Config {
-		{Size: 40},
-		{Size: 100},
-		{Size: 250},
+	testCases := []struct{
+		config loadtest.Config
+		clientCount int
+	}{
+		{loadtest.Config{Size: 32, Count: 1000}, 5},
+		{loadtest.Config{Size: 64, Count: 1000}, 5},
+		{loadtest.Config{Size: 128, Count: 1000}, 5},
+		{loadtest.Config{Size: 256, Count: 1000}, 5},
+		{loadtest.Config{Size: 10240, Count: 1000}, 5},
 	}
 	factory := loadtest.NewKVStoreClientFactory()
-	clientCounter := uint32(0)
 	for i, tc := range testCases {
-		err := factory.ValidateConfig(tc)
+		err := factory.ValidateConfig(tc.config)
 		if err != nil {
 			t.Errorf("Expected config from test case %d to validate, but failed: %v", i, err)
 		}
 
-		for c := uint32(0); c < 2; c++ {
-			client, err := factory.NewClient(tc)
+		for c := 0; c < tc.clientCount; c++ {
+			client, err := factory.NewClient(tc.config)
 			if err != nil {
 				t.Errorf("Did not expect error in test case %d from factory.NewClient: %v", i, err)
 			}
@@ -52,15 +117,9 @@ func TestKVStoreClient(t *testing.T) {
 			if err != nil {
 				t.Errorf("Did not expect error in test case %d from client %d's GenerateTx: %v", i, c, err)
 			}
-			if len(tx) != tc.Size {
-				t.Errorf("Expected transaction from client %d in test case %d to be %d bytes, but was %d bytes", c, i, tc.Size, len(tx))
+			if len(tx) != tc.config.Size {
+				t.Errorf("Expected transaction from client %d in test case %d to be %d bytes, but was %d bytes", c, i, tc.config.Size, len(tx))
 			}
-			// check that the client's 4-byte ID is embedded in the transaction
-			embeddedID := binary.LittleEndian.Uint32(tx[0:4])
-			if clientCounter != embeddedID {
-				t.Errorf("Expected transaction prefix from client %d in test case %d to be %d, but was %d", c, i, clientCounter, embeddedID)
-			}
-			clientCounter++
 		}
 	}
 }

--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -64,8 +64,13 @@ func (c Config) Validate() error {
 	if len(c.ClientFactory) == 0 {
 		return fmt.Errorf("client factory name must be specified")
 	}
-	if _, exists := clientFactories[c.ClientFactory]; !exists {
+	factory, factoryExists := clientFactories[c.ClientFactory]
+	if !factoryExists {
 		return fmt.Errorf("client factory \"%s\" does not exist", c.ClientFactory)
+	}
+	// client factory-specific configuration validation
+	if err := factory.ValidateConfig(c); err != nil {
+		return fmt.Errorf("invalid configuration for client factory \"%s\": %v", c.ClientFactory, err)
 	}
 	if c.Connections < 1 {
 		return fmt.Errorf("expected connections to be >= 1, but was %d", c.Connections)
@@ -78,9 +83,6 @@ func (c Config) Validate() error {
 	}
 	if c.Rate < 1 {
 		return fmt.Errorf("expected transaction rate to be >= 1, but was %d", c.Rate)
-	}
-	if c.Size < 40 {
-		return fmt.Errorf("expected transaction size to be >= 40 bytes, but was %d", c.Size)
 	}
 	if c.Count < 1 && c.Count != -1 {
 		return fmt.Errorf("expected max transaction count to either be -1 or >= 1, but was %d", c.Count)

--- a/pkg/loadtest/config.go
+++ b/pkg/loadtest/config.go
@@ -111,6 +111,15 @@ func (c Config) Validate() error {
 	return nil
 }
 
+// MaxTxsPerEndpoint estimates the maximum number of transactions that this
+// configuration would generate for a single endpoint.
+func (c Config) MaxTxsPerEndpoint() uint64 {
+	if c.Count > -1 {
+		return uint64(c.Count)
+	}
+	return uint64(c.Rate) * uint64(c.Time)
+}
+
 func (c MasterConfig) ToJSON() string {
 	b, err := json.Marshal(c)
 	if err != nil {

--- a/pkg/loadtest/messages.go
+++ b/pkg/loadtest/messages.go
@@ -2,9 +2,10 @@ package loadtest
 
 // A generic message to/from a slave.
 type slaveMsg struct {
-	ID      string     `json:"id,omitempty"`       // A UUID for this slave.
-	State   slaveState `json:"state,omitempty"`    // The slave's desired or actual state.
-	TxCount int        `json:"tx_count,omitempty"` // The total number of transactions sent thus far by this slave.
-	Error   string     `json:"error,omitempty"`    // If the slave has failed somehow, a descriptive error message as to why.
-	Config  *Config    `json:"config,omitempty"`   // The load testing configuration, if relevant.
+	ID           string     `json:"id,omitempty"`             // A UUID for this slave.
+	State        slaveState `json:"state,omitempty"`          // The slave's desired or actual state.
+	TxCount      int        `json:"tx_count,omitempty"`       // The total number of transactions sent thus far by this slave.
+	TotalTxBytes int64      `json:"total_tx_bytes,omitempty"` // The total number of transaction bytes sent thus far by this slave.
+	Error        string     `json:"error,omitempty"`          // If the slave has failed somehow, a descriptive error message as to why.
+	Config       *Config    `json:"config,omitempty"`         // The load testing configuration, if relevant.
 }

--- a/pkg/loadtest/stats.go
+++ b/pkg/loadtest/stats.go
@@ -6,11 +6,38 @@ import (
 	"os"
 )
 
-func writeAggregateStats(filename string, totalTxs int, totalTimeSeconds float64) error {
-	avgTxRate := float64(0)
-	if totalTimeSeconds > 0.0 {
-		avgTxRate = float64(totalTxs) / totalTimeSeconds
+type AggregateStats struct {
+	TotalTxs         int     // The total number of transactions sent.
+	TotalTimeSeconds float64 // The total time taken to send `TotalTxs` transactions.
+	TotalBytes       int64   // The cumulative number of bytes sent as transactions.
+
+	// Computed statistics
+	AvgTxRate   float64 // The rate at which transactions were submitted (tx/sec).
+	AvgDataRate float64 // The rate at which data was transmitted in transactions (bytes/sec).
+}
+
+func (s *AggregateStats) String() string {
+	return fmt.Sprintf(
+		"AggregateStats{TotalTimeSeconds: %.3f, TotalTxs: %d, TotalBytes: %d, AvgTxRate: %.6f, AvgDataRate: %.6f}",
+		s.TotalTimeSeconds,
+		s.TotalTxs,
+		s.TotalBytes,
+		s.AvgTxRate,
+		s.AvgDataRate,
+	)
+}
+
+func (s *AggregateStats) Compute() {
+	s.AvgTxRate = 0
+	s.AvgDataRate = 0
+	if s.TotalTimeSeconds > 0.0 {
+		s.AvgTxRate = float64(s.TotalTxs) / s.TotalTimeSeconds
+		s.AvgDataRate = float64(s.TotalBytes) / s.TotalTimeSeconds
 	}
+}
+
+func writeAggregateStats(filename string, stats AggregateStats) error {
+	stats.Compute()
 	f, err := os.Create(filename)
 	if err != nil {
 		return err
@@ -22,9 +49,11 @@ func writeAggregateStats(filename string, totalTxs int, totalTimeSeconds float64
 
 	records := [][]string{
 		{"Parameter", "Value", "Units"},
-		{"total_time", fmt.Sprintf("%.3f", totalTimeSeconds), "seconds"},
-		{"total_txs", fmt.Sprintf("%d", totalTxs), "count"},
-		{"avg_tx_rate", fmt.Sprintf("%.6f", avgTxRate), "transactions per second"},
+		{"total_time", fmt.Sprintf("%.3f", stats.TotalTimeSeconds), "seconds"},
+		{"total_txs", fmt.Sprintf("%d", stats.TotalTxs), "count"},
+		{"total_bytes", fmt.Sprintf("%d", stats.TotalBytes), "bytes"},
+		{"avg_tx_rate", fmt.Sprintf("%.6f", stats.AvgTxRate), "transactions per second"},
+		{"avg_data_rate", fmt.Sprintf("%.6f", stats.AvgDataRate), "bytes per second"},
 	}
 	return w.WriteAll(records)
 }

--- a/pkg/loadtest/tm_network_info.go
+++ b/pkg/loadtest/tm_network_info.go
@@ -45,8 +45,8 @@ func waitForTendermintNetworkPeers(
 	)
 
 	cancelc := make(chan struct{}, 1)
-	cancelTrap := trapInterrupts(func() { close(cancelc); }, logger);
-	defer close(cancelTrap);
+	cancelTrap := trapInterrupts(func() { close(cancelc) }, logger)
+	defer close(cancelTrap)
 	startTime := time.Now()
 	suppliedPeers := make(map[string]*tendermintPeerInfo)
 	for _, peerURL := range startingPeerAddrs {

--- a/pkg/loadtest/transactor.go
+++ b/pkg/loadtest/transactor.go
@@ -66,7 +66,7 @@ func NewTransactor(remoteAddr string, config *Config) (*Transactor, error) {
 	if !exists {
 		return nil, fmt.Errorf("unrecognized client factory: %s", config.ClientFactory)
 	}
-	client, err := clientFactory.NewClient()
+	client, err := clientFactory.NewClient(*config)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #46 

Also introduces some new Prometheus metrics and aggregate stats that track overall transaction throughput and throughput rate in bytes and bytes/sec (respectively). This aids with testing and integration testing of this improvement.